### PR TITLE
AC-3 Call Tracking and Undoing

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -80,6 +80,7 @@
     "forward_list": "cpp",
     "span": "cpp",
     "valarray": "cpp",
-    "ranges": "cpp"
+    "ranges": "cpp",
+    "filesystem": "cpp"
   }
 }

--- a/src/cli/cw_gen.cpp
+++ b/src/cli/cw_gen.cpp
@@ -38,9 +38,9 @@ string cw_gen::squash_options(vector<string> options) {
 */
 void cw_gen::build() {
     if(has_grid_contents) {
-        csp = make_unique<cw_csp>("puzzle", length, height, contents, dict_path[dict]);
+        csp = make_unique<cw_csp>("puzzle", length, height, contents, dict_path[dict], display_progress_bar);
     } else {
-        csp = make_unique<cw_csp>("puzzle", length, height, dict_path[dict]);
+        csp = make_unique<cw_csp>("puzzle", length, height, dict_path[dict], display_progress_bar);
     }
 }
 

--- a/src/cli/cw_gen.h
+++ b/src/cli/cw_gen.h
@@ -47,7 +47,7 @@ namespace cw_gen_ns {
             void build();
 
             // attempt to solve crossword puzzle, return true iff successful
-            bool solve() { assert(csp != nullptr); return csp->solve(BACKTRACKING, MIN_REMAINING_VALUES, display_progress_bar) && csp->solved(); }
+            bool solve() { assert(csp != nullptr); return csp->solve(BACKTRACKING, MIN_REMAINING_VALUES) && csp->solved(); }
 
             // return result after running solve()
             string result() { assert(csp->solved()); return csp->result(); }

--- a/src/common/common_data_types.h
+++ b/src/common/common_data_types.h
@@ -88,7 +88,7 @@ namespace common_data_types_ns {
 
     /**
      * @brief progress bar to print cw search progress
-     * implementation largely borrowed from https://codereview.stackexchange.com/a/186537
+     * @cite https://codereview.stackexchange.com/a/186537
     */
     class progress_bar {
         public:

--- a/src/common/common_data_types.h
+++ b/src/common/common_data_types.h
@@ -29,6 +29,11 @@
 #define BLK BLACK              // shorthand
 #define NUM_ENGLISH_LETTERS 26 // this shouldn't ever change, knock on wood :)
 
+// cosmetics
+#define PROGRESS_BAR_WIDTH 100u
+#define PROGRESS_BAR_SYMBOL_FULL '#'
+#define PROGRESS_BAR_SYMBOL_EMPTY '.'
+
 using std::cout;
 using std::cerr;
 using std::endl;

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -14,11 +14,13 @@ using namespace cw_csp_ns;
  * @param length the length of puzzle to be created
  * @param height the height of puzzle to be created
  * @param filepath relative filepath to dictionary of words file
+ * @param print_progress_bar displays progress bar iff true, default: false
 */
-cw_csp::cw_csp(string name, uint length, uint height, string filepath) 
+cw_csp::cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar) 
         : common_parent(name), 
           cw(name + " cw", length, height), 
-          total_domain(name + " total_domain", filepath) {
+          total_domain(name + " total_domain", filepath, print_progress_bar), 
+          print_progress_bar(print_progress_bar) {
     initialize_csp();
 }
 
@@ -29,11 +31,13 @@ cw_csp::cw_csp(string name, uint length, uint height, string filepath)
  * @param height the height of puzzle to be created
  * @param contents the contents to populate puzzle with
  * @param filepath relative filepath to dictionary of words file
+ * @param print_progress_bar displays progress bar iff true, default: false
 */
-cw_csp::cw_csp(string name, uint length, uint height, string contents, string filepath) 
+cw_csp::cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar) 
         : common_parent(name), 
           cw(name + " cw", length, height, contents), 
-          total_domain(name + " total_domain", filepath) {
+          total_domain(name + " total_domain", filepath, print_progress_bar), 
+          print_progress_bar(print_progress_bar) {
     initialize_csp();
 }
 
@@ -541,10 +545,9 @@ shared_ptr<cw_variable> cw_csp::select_unassigned_var(var_selection_method strat
  * 
  * @param csp_strategy strategy to solve this CSP
  * @param var_strategy strategy to select next unassigned variable
- * @param print_progress_bar true for prod to avoid printing during testing
  * @return true iff successful
 */
-bool cw_csp::solve(csp_solving_strategy csp_strategy, var_selection_method var_strategy, bool print_progress_bar) {
+bool cw_csp::solve(csp_solving_strategy csp_strategy, var_selection_method var_strategy) {
     // base case for initially invalid crosswords
     if(!ac3()) return false;
 
@@ -566,10 +569,10 @@ bool cw_csp::solve(csp_solving_strategy csp_strategy, var_selection_method var_s
  * @brief use backtracking strategy to solve CSP
  * 
  * @param var_strategy strategy to use to select next unassigned variable 
- * @param print_progress_bar true for top level call in prod to avoid printing during testing
+ * @param do_progress_bar true for top level call in prod to avoid printing during testing
  * @return true iff successful
 */
-bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool print_progress_bar) {
+bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool do_progress_bar) {
 
     ss << "entering solve_backtracking() with cw: " << cw;
     utils->print_msg(&ss, DEBUG);
@@ -592,8 +595,8 @@ bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool print_pr
     unique_ptr<progress_bar> bar = nullptr;
     double prev_progress = 0.0;
     int words_searched = 0;
-    if(print_progress_bar) {
-        bar = make_unique<progress_bar>(cout, 100u, "Searching", '#', '.');
+    if(do_progress_bar) {
+        bar = make_unique<progress_bar>(cout, PROGRESS_BAR_WIDTH, "Searching", PROGRESS_BAR_SYMBOL_FULL, PROGRESS_BAR_SYMBOL_EMPTY);
     }
 
     // search all possible values, sorted by word score, tiebroken by frequency
@@ -608,7 +611,7 @@ bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool print_pr
     for(word_t word : domain_copy) {
         
         // update progress bar if 1% more of progress made
-        if(print_progress_bar && (double)words_searched/domain_copy.size() >= prev_progress + 0.01) {
+        if(do_progress_bar && (double)words_searched/domain_copy.size() >= prev_progress + 0.01) {
             prev_progress += 0.01;
             bar->write(prev_progress);
         }

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -128,7 +128,7 @@ void cw_csp::initialize_csp() {
                     // single letters are not full words
                     if(cur_var_len >= MIN_WORD_LEN) {
                         // save new variable
-                        shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain);
+                        shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
                         ss << "adding new variable: " << *new_var;
                         utils->print_msg(&ss, DEBUG);
                         variables.insert(new_var);
@@ -148,7 +148,7 @@ void cw_csp::initialize_csp() {
 
         if(traversing_word && cur_var_len >= MIN_WORD_LEN) {
             // applicable if the last space in a row is blank
-            shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain);
+            shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
             ss << "adding new variable: " << *new_var;
             utils->print_msg(&ss, DEBUG);
             variables.insert(new_var);
@@ -192,7 +192,7 @@ void cw_csp::initialize_csp() {
                     // single letters are not full words
                     if(cur_var_len >= MIN_WORD_LEN) {
                         // save new variable
-                        shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain);
+                        shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
                         ss << "adding new variable: " << *new_var;
                         utils->print_msg(&ss, DEBUG);
                         variables.insert(new_var);
@@ -212,7 +212,7 @@ void cw_csp::initialize_csp() {
 
         if(traversing_word && cur_var_len >= MIN_WORD_LEN) {
             // applicable if the last 2+ spaces in a row are blank
-            shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain);
+            shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
             ss << "adding new variable: " << *new_var;
             utils->print_msg(&ss, DEBUG);
             variables.insert(new_var);

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -28,10 +28,10 @@ namespace cw_csp_ns {
     class cw_csp : public common_parent {
         public:
             // constructor w/o puzzle contents
-            cw_csp(string name, uint length, uint height, string filepath);
+            cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar = false);
 
             // constructor with puzzle contents
-            cw_csp(string name, uint length, uint height, string contents, string filepath);
+            cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar = false);
 
             // read-only getters for testing
             unordered_set<cw_variable>                                get_variables()        const;
@@ -39,7 +39,7 @@ namespace cw_csp_ns {
             unordered_map<cw_variable, unordered_set<cw_constraint> > get_arc_dependencies() const;
 
             // solve CSP
-            bool solve(csp_solving_strategy csp_strategy, var_selection_method var_strategy, bool print_progress_bar);
+            bool solve(csp_solving_strategy csp_strategy, var_selection_method var_strategy);
 
             // execute AC-3 algorithm to reduce CSP
             bool ac3();
@@ -70,7 +70,7 @@ namespace cw_csp_ns {
             void undo_overwrite_cw();
 
             // use backtracking to solve CSP
-            bool solve_backtracking(var_selection_method var_strategy, bool print_progress_bar);
+            bool solve_backtracking(var_selection_method var_strategy, bool do_progress_bar);
 
         private:
             // crossword to be solved
@@ -94,6 +94,9 @@ namespace cw_csp_ns {
 
             // words already assigned to the crossword, used to avoid duplicates
             unordered_set<word_t> assigned_words;
+
+            // progress bar for searching and domain building
+            bool print_progress_bar;
 
     }; // cw_csp
 } // cw_csp_ns

--- a/src/cw_csp/cw_csp_data_types.cpp
+++ b/src/cw_csp/cw_csp_data_types.cpp
@@ -73,18 +73,15 @@ ostream& cw_csp_data_types_ns::operator<<(ostream& os, const cw_variable& var) {
  * @param length num of letters in this var
  * @param dir direction of this var
  * @param pattern word pattern to find matches for to populate domain
- * @param total_domain ref to cw_trie of all words to populate domain with
+ * @param domain contents of domain of this var
 */
-cw_variable::cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, cw_trie& total_domain) {
+cw_variable::cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, unordered_set<word_t> domain) {
     this->origin_row = origin_row;
     this->origin_col = origin_col;
     this->length = length;
     this->dir = dir;
     this->pattern = pattern;
-    domain.clear();
-
-    // populate domain
-    total_domain.find_matches(domain, pattern);
+    this->domain = domain;
 }
 
 /**

--- a/src/cw_csp/cw_csp_data_types.h
+++ b/src/cw_csp/cw_csp_data_types.h
@@ -50,7 +50,7 @@ namespace cw_csp_data_types_ns {
         bool assigned = false;        // true iff assigned to single value --> domain.size() == 1
 
         // standard constructor for cw_csp
-        cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, cw_trie& total_domain);
+        cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, unordered_set<word_t> domain);
 
         // testing-only constructor
         cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, unordered_set<word_t> domain);

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -603,17 +603,3 @@ void cw_trie::collect_cur_domain(shared_ptr<trie_node> node, string fragment, ve
         collect_cur_domain(pair.second, fragment_with_cur_node, acc);
     }
 }
-
-/**
- * @brief remove_matching_words() helper to get the string fragment terminating at this node
- * 
- * @param node the current node being read and has not been added to result yet
- * @return string fragment of word before and including the provided node
-*/
-string cw_trie::get_fragment(shared_ptr<trie_node> node) {
-    if(auto p = node->parent.lock()) {
-        return get_fragment(p) + node->letter;
-    }
-
-    return "";
-}

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -95,6 +95,27 @@ cw_trie::cw_trie(string name, optional<string> filepath_opt) : common_parent(nam
 }
 
 /**
+ * @brief constructor for cw_trie with hashset of words in domain
+ * @warning behavior undefined unless called to initialize a domain for a cw_variable
+ * 
+ * @param name the name of this object
+ * @param domain set of words to add to domain, whose words must all be equal length
+*/
+cw_trie::cw_trie(string name, unordered_set<word_t> domain) : common_parent(name) {
+    trie = make_shared<trie_node>(false, '_', nullptr);
+    filepath_opt = std::nullopt;
+    unassigned_domain_size = 0;
+    assigned = false;
+
+    size_t word_len = 0;
+    for(word_t word : domain) {
+        assert_m(word_len == 0 || word_len == word.word.size(), "cw_trie set constructor includes words of unequal length");
+        word_len = word.word.size();
+        add_word(word);
+    }
+}
+
+/**
  * @brief helper for filepath constructor to detect file type
  * 
  * @param str string to check the suffix of

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -216,12 +216,13 @@ bool cw_trie::is_word(string& word) const {
 /**
  * @brief adds all words that match pattern with WILDCARD ('?') as placeholder
  * 
- * @param matches ref to set to add matches to
  * @param pattern the pattern to compare against
  * @note behavior undefined if domain assigned, only intended to be called in cw_variable initialization
 */
-void cw_trie::find_matches(unordered_set<word_t>& matches, string& pattern) {
+unordered_set<word_t> cw_trie::find_matches(const string& pattern) {
+    unordered_set<word_t> matches;
     traverse_to_find_matches(matches, pattern, 0, trie, "");
+    return matches;
 }
 
 /**
@@ -233,7 +234,7 @@ void cw_trie::find_matches(unordered_set<word_t>& matches, string& pattern) {
  * @param node current node traversing in word_tree
  * @param fragment part of word matched already
 */
-void cw_trie::traverse_to_find_matches(unordered_set<word_t>& matches, string& pattern, uint pos, shared_ptr<trie_node> node, string fragment) {
+void cw_trie::traverse_to_find_matches(unordered_set<word_t>& matches, const string& pattern, uint pos, shared_ptr<trie_node> node, string fragment) {
     ss << "entering traverse_to_find_matches() w/ pattern " << pattern << " at pos " << pos 
        << " @ node " << node->letter;
     utils->print_msg(&ss, DEBUG);

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -481,7 +481,7 @@ size_t cw_trie::undo_prev_ac3_call() {
             assert_m(letters_at_indices[i][j].ac3_pruned_children.size() == stack_depth, "stack depth invariant violated for ac3_pruned_children");
         }
     }
-
+    
     size_t num_restored = 0;
     for(uint i = 0; i < MAX_WORD_LEN; i++) {
         for(uint j = 0; j < NUM_ENGLISH_LETTERS; j++) {

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -552,12 +552,12 @@ size_t cw_trie::domain_size() const {
 /**
  * @brief get letters at an index in the current domain, for AC-3 constraint satisfaction checking
  * @param index the index to get letters for
- * @returns vector of chars, >= 'a', and <= 'z', which appear at the specific index in the current domain (taking into account assignment) 
+ * @returns set of chars, >= 'a', and <= 'z', which appear at the specific index in the current domain (taking into account assignment) 
 */
-vector<char> cw_trie::get_all_letters_at_index(uint index) const {
-    assert(index < MAX_WORD_LEN);
+unordered_set<char> cw_trie::get_all_letters_at_index(uint index) const {
+    assert_m(index < MAX_WORD_LEN, "index out of bounds of max word length");
 
-    vector<char> result;
+    unordered_set<char> result;
     if(assigned) {
         if(assigned_value.has_value()) {
             assert_m(index < assigned_value.value().word.size(), "index out of bounds in letters_at_index() call");
@@ -567,7 +567,7 @@ vector<char> cw_trie::get_all_letters_at_index(uint index) const {
     } else {
         for(char letter = 'a'; letter <= 'z'; letter++) {
             if(num_letters_at_index(index, letter) > 0) {
-                result.push_back(letter);
+                result.insert(letter);
             }
         }
     } 

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -535,6 +535,32 @@ size_t cw_trie::domain_size() const {
 }
 
 /**
+ * @brief get letters at an index in the current domain, for AC-3 constraint satisfaction checking
+ * @param index the index to get letters for
+ * @returns vector of chars, >= 'a', and <= 'z', which appear at the specific index in the current domain (taking into account assignment) 
+*/
+vector<char> cw_trie::letters_at_index(uint index) const {
+    assert(index < MAX_WORD_LEN);
+
+    vector<char> result;
+    if(assigned) {
+        if(assigned_value.has_value()) {
+            assert_m(index < assigned_value.value().word.size(), "index out of bounds in letters_at_index() call");
+            
+            result = { assigned_value.value().word.at(index) };
+        }
+    } else {
+        for(char letter = 'a'; letter <= 'z'; letter++) {
+            if(num_letters_at_index(index, letter) > 0) {
+                result.push_back(letter);
+            }
+        }
+    } 
+    
+    return result;
+}
+
+/**
  * @brief testing method to enforce invariant that the sum of num_words for each letter index in letters_at_indices should equal unassigned_domain_size
  * @invariant sum of num_words for each letter index in letters_at_indices should equal unassigned_domain_size
  * @deprecated

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -577,7 +577,7 @@ vector<char> cw_trie::get_all_letters_at_index(uint index) const {
 
 /**
  * @brief get vector containing all words in the current domain
- * @returns vector of all words in the current domain
+ * @returns unsorted vector of all words in the current domain
 */
 vector<word_t> cw_trie::get_cur_domain() {
     vector<word_t> acc;

--- a/src/cw_trie/cw_trie.cpp
+++ b/src/cw_trie/cw_trie.cpp
@@ -548,7 +548,7 @@ size_t cw_trie::domain_size() const {
  * @param index the index to get letters for
  * @returns vector of chars, >= 'a', and <= 'z', which appear at the specific index in the current domain (taking into account assignment) 
 */
-vector<char> cw_trie::letters_at_index(uint index) const {
+vector<char> cw_trie::get_all_letters_at_index(uint index) const {
     assert(index < MAX_WORD_LEN);
 
     vector<char> result;
@@ -567,6 +567,41 @@ vector<char> cw_trie::letters_at_index(uint index) const {
     } 
     
     return result;
+}
+
+/**
+ * @brief get vector containing all words in the current domain
+ * @returns vector of all words in the current domain
+*/
+vector<word_t> cw_trie::get_cur_domain() {
+    vector<word_t> acc;
+    collect_cur_domain(trie, "", acc);
+    return acc;
+}
+
+/**
+ * @brief helper for get_cur_domain(), traverses trie and adds words to accumulator
+ * 
+ * @param node current node in the traversal
+ * @param fragment letters from traversal so far up to and not including the current node
+ * @param acc accumulator vector to write back valid words to
+*/
+void cw_trie::collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc) {
+    string fragment_with_cur_node = fragment + node->letter;
+
+    // base case for leaf nodes
+    if(node->valid) {
+        // terminates valid word, assumed to be a leaf node since all domain values in cw_variable are equal length
+        assert(node->children.size() == 0);
+
+        acc.push_back(word_map.at(fragment_with_cur_node));
+        return;
+    }
+
+    // recursive calls to children
+    for(const auto& pair : node->children) {
+        collect_cur_domain(pair.second, fragment_with_cur_node, acc);
+    }
 }
 
 /**

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -81,9 +81,11 @@ namespace cw_trie_ns {
             shared_ptr<trie_node> trie;
 
             // map of all words to word structs (with heuristics) for O(1) validity checking & struct lookup for find_matches()
-            // contents undefined if assigned (contains data for previous trie)
-            // TODO: should this be removed?
+            // contents include all words added, even if pruned during an AC-3 call or this domain is assigned a value
             unordered_map<string, word_t> word_map;
+
+            // number of words currently in domain, ignoring any assigned value
+            size_t unassigned_domain_size;
 
             // stores # of words with letters at each index
             // contents undefined if domain assigned
@@ -117,6 +119,9 @@ namespace cw_trie_ns {
 
             // downwards recursive deletion helper func for remove_matching_words()
             uint remove_children(shared_ptr<trie_node> node, unordered_set<word_t>& pruned_words, uint index, string fragment);
+
+            // enforces invariant that the sum of num_words for each letter index in letters_at_indices should equal unassigned_domain_size
+            void enforce_domain_size_ok();
 
             // helper for remove_matching_words(), gets preceding word fragment from a node targeted for removal
             // TODO: should this be removed?

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -28,6 +28,9 @@ namespace cw_trie_ns {
             // constructor with filepath opt
             cw_trie(string name, optional<string> filepath_opt);
 
+            // constructor with set of domain, exclusively for cw_variable domain representation
+            cw_trie(string name, unordered_set<word_t> domain);
+
             // add word to trie
             // TODO: should this be by reference?
             void add_word(word_t w); 

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -44,7 +44,7 @@ namespace cw_trie_ns {
             uint num_letters_at_index(uint index, char letter) const;
 
             // deletion function for words with letters at an index
-            size_t remove_matching_words(unordered_set<word_t>& pruned_words, uint index, char letter);
+            size_t remove_matching_words(uint index, char letter);
 
             // start new AC-3 algorithm call
             // i.e. add new blank layer to letters_at_indices.ac3_pruned_nodes and ac3_pruned_assigned_val
@@ -119,10 +119,7 @@ namespace cw_trie_ns {
             void remove_from_parents(shared_ptr<trie_node> node, uint& num_leafs, int index, bool letters_at_indices_updated);
 
             // downwards recursive deletion helper func for remove_matching_words()
-            uint remove_children(shared_ptr<trie_node> node, unordered_set<word_t>& pruned_words, uint index, string fragment);
-
-            // enforces invariant that the sum of num_words for each letter index in letters_at_indices should equal unassigned_domain_size
-            void enforce_domain_size_ok();
+            uint remove_children(shared_ptr<trie_node> node, uint index);
 
             // helper for remove_matching_words(), gets preceding word fragment from a node targeted for removal
             // TODO: should this be removed?

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -23,10 +23,10 @@ namespace cw_trie_ns {
             cw_trie(string name);
             
             // constructor with filepath
-            cw_trie(string name, string filepath);
+            cw_trie(string name, string filepath, bool print_progress_bar = false);
 
             // constructor with filepath opt
-            cw_trie(string name, optional<string> filepath_opt);
+            cw_trie(string name, optional<string> filepath_opt, bool print_progress_bar = false);
 
             // constructor with set of domain, exclusively for cw_variable domain representation
             cw_trie(string name, unordered_set<word_t> domain);

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -36,13 +36,17 @@ namespace cw_trie_ns {
 
             // find all words that match a pattern
             // TODO: add const correctness
-            void find_matches(unordered_set<word_t>& matches, string& pattern);
+            unordered_set<word_t> find_matches(const string& pattern);
 
             // read function for entries in letters_at_indices
             uint num_letters_at_index(uint index, char letter) const;
 
             // deletion function for words with letters at an index
             void remove_matching_words(unordered_set<word_t>& pruned_words, uint index, char letter);
+
+            // start new AC-3 algorithm call, i.e. add new blank layer to  
+
+            // undo previous AC-3 algorithm call, i.e. pop top layer of 
 
             // assign domain to a single value, repeat calls overwrite assigned value
             void assign_domain(word_t new_value) { assigned = true; assigned_value = new_value; }
@@ -76,6 +80,10 @@ namespace cw_trie_ns {
             // contents undefined if domain assigned
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> letters_at_indices;
 
+            // each layer corresponds to one call to AC-3 algorithm, and contains nodes pruned from each element in letters_at_indices
+            // top layer corresponds to most recent AC-3 call
+            // stack<array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > ac3_pruned_stack;
+
             // true iff domain has been assigned to a single value --> ignore trie
             bool assigned;
 
@@ -93,7 +101,7 @@ namespace cw_trie_ns {
 
             // helper function for find_matches()
             // TODO: add const correctness
-            void traverse_to_find_matches(unordered_set<word_t>& matches, string& pattern, uint pos, shared_ptr<trie_node> node, string fragment);
+            void traverse_to_find_matches(unordered_set<word_t>& matches, const string& pattern, uint pos, shared_ptr<trie_node> node, string fragment);
 
             // upwards recursive deletion helper func for remove_matching_words()
             void remove_from_parents(shared_ptr<trie_node> node, uint& num_leafs, int index, bool letters_at_indices_updated);

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -67,7 +67,7 @@ namespace cw_trie_ns {
             size_t domain_size() const;
 
             // get letters at an index, for AC-3 constraint satisfaction checking
-            vector<char> get_all_letters_at_index(uint index) const;
+            unordered_set<char> get_all_letters_at_index(uint index) const;
 
             // get all words in current domain to try to assign for backtracking
             vector<word_t> get_cur_domain();

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -127,10 +127,6 @@ namespace cw_trie_ns {
 
             // helper for get_cur_domain() to traverse trie and collect words
             void collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc);
-
-            // helper for remove_matching_words(), gets preceding word fragment from a node targeted for removal
-            // TODO: should this be removed?
-            string get_fragment(shared_ptr<trie_node> node);
     }; // cw_trie
 }; // cw_trie_ns
 

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -28,10 +28,12 @@ namespace cw_trie_ns {
             // constructor with filepath opt
             cw_trie(string name, optional<string> filepath_opt);
 
-            // add word to trie, TODO: should this be by reference?
+            // add word to trie
+            // TODO: should this be by reference?
             void add_word(word_t w); 
 
             // word check
+            // TODO: should this be removed?
             bool is_word(string& word) const;
 
             // find all words that match a pattern
@@ -42,11 +44,15 @@ namespace cw_trie_ns {
             uint num_letters_at_index(uint index, char letter) const;
 
             // deletion function for words with letters at an index
-            void remove_matching_words(unordered_set<word_t>& pruned_words, uint index, char letter);
+            size_t remove_matching_words(unordered_set<word_t>& pruned_words, uint index, char letter);
 
-            // start new AC-3 algorithm call, i.e. add new blank layer to  
+            // start new AC-3 algorithm call
+            // i.e. add new blank layer to letters_at_indices.ac3_pruned_nodes and ac3_pruned_assigned_val
+            void start_new_ac3_call();
 
-            // undo previous AC-3 algorithm call, i.e. pop top layer of 
+            // undo previous AC-3 algorithm call
+            // i.e. pop top layers of letters_at_indices.ac3_pruned_nodes and ac3_pruned_assigned_val, and restore to trie and assigned_value
+            size_t undo_prev_ac3_call();
 
             // assign domain to a single value, repeat calls overwrite assigned value
             void assign_domain(word_t new_value) { assigned = true; assigned_value = new_value; }
@@ -57,13 +63,13 @@ namespace cw_trie_ns {
             // get size of domain remaining, for ac3 validity checking
             size_t domain_size() const;
 
+            // TODO: add function to get list of letters at an index, for ac3 validity checking
+
             // expose letters_at_indicies for testing
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> get_letters_at_indices() { return letters_at_indices; }
 
             // expose word_map for testing, undefined if domain assigned
             unordered_map<string, word_t>& get_word_map() { return word_map; }
-
-            // TODO: maybe add something to undo the previous call to remove_matching_words()
         
         private:
             // opt file that this object may have read from
@@ -74,15 +80,16 @@ namespace cw_trie_ns {
 
             // map of all words to word structs (with heuristics) for O(1) validity checking & struct lookup for find_matches()
             // contents undefined if assigned (contains data for previous trie)
+            // TODO: should this be removed?
             unordered_map<string, word_t> word_map;
 
             // stores # of words with letters at each index
             // contents undefined if domain assigned
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> letters_at_indices;
 
-            // each layer corresponds to one call to AC-3 algorithm, and contains nodes pruned from each element in letters_at_indices
+            // each layer corresponds to one call to AC-3 algorithm, and possibly contains a pruned assigned value 
             // top layer corresponds to most recent AC-3 call
-            // stack<array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > ac3_pruned_stack;
+            stack<optional<word_t> > ac3_pruned_assigned_val;
 
             // true iff domain has been assigned to a single value --> ignore trie
             bool assigned;
@@ -110,6 +117,7 @@ namespace cw_trie_ns {
             uint remove_children(shared_ptr<trie_node> node, unordered_set<word_t>& pruned_words, uint index, string fragment);
 
             // helper for remove_matching_words(), gets preceding word fragment from a node targeted for removal
+            // TODO: should this be removed?
             string get_fragment(shared_ptr<trie_node> node);
     }; // cw_trie
 }; // cw_trie_ns

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -67,9 +67,10 @@ namespace cw_trie_ns {
             size_t domain_size() const;
 
             // get letters at an index, for AC-3 constraint satisfaction checking
-            vector<char> letters_at_index(uint index) const;
+            vector<char> get_all_letters_at_index(uint index) const;
 
-            // TODO: add function to get list of words to try to assign for backtracking
+            // get all words in current domain to try to assign for backtracking
+            vector<word_t> get_cur_domain();
 
             // expose letters_at_indicies for testing
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> get_letters_at_indices() { return letters_at_indices; }
@@ -85,7 +86,7 @@ namespace cw_trie_ns {
             shared_ptr<trie_node> trie;
 
             // map of all words to word structs (with heuristics) for O(1) validity checking & struct lookup for find_matches()
-            // contents include all words added, even if pruned during an AC-3 call or this domain is assigned a value
+            // contents include all words ever added, even if pruned during an AC-3 call or this domain is assigned a value
             unordered_map<string, word_t> word_map;
 
             // number of words currently in domain, ignoring any assigned value
@@ -123,6 +124,9 @@ namespace cw_trie_ns {
 
             // downwards recursive deletion helper func for remove_matching_words()
             uint remove_children(shared_ptr<trie_node> node, uint index);
+
+            // helper for get_cur_domain() to traverse trie and collect words
+            void collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc);
 
             // helper for remove_matching_words(), gets preceding word fragment from a node targeted for removal
             // TODO: should this be removed?

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -65,6 +65,8 @@ namespace cw_trie_ns {
 
             // TODO: add function to get list of letters at an index, for ac3 validity checking
 
+            // TODO: add function to get list of words to try to assign for backtracking
+
             // expose letters_at_indicies for testing
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> get_letters_at_indices() { return letters_at_indices; }
 

--- a/src/cw_trie/cw_trie.h
+++ b/src/cw_trie/cw_trie.h
@@ -63,7 +63,8 @@ namespace cw_trie_ns {
             // get size of domain remaining, for ac3 validity checking
             size_t domain_size() const;
 
-            // TODO: add function to get list of letters at an index, for ac3 validity checking
+            // get letters at an index, for AC-3 constraint satisfaction checking
+            vector<char> letters_at_index(uint index) const;
 
             // TODO: add function to get list of words to try to assign for backtracking
 

--- a/src/cw_trie/cw_trie_data_types.h
+++ b/src/cw_trie/cw_trie_data_types.h
@@ -43,14 +43,29 @@ namespace cw_trie_data_types_ns {
         // after remove_matching_words() is called, ptrs to nodes are still kept here as a backup and can be restored if needed
         unordered_set<shared_ptr<trie_node> > nodes;
 
-        // for these fields below, each layer corresponds to one call to AC-3 algorithm
-        // top layer corresponds to most recent AC-3 call
-        //   contains nodes pruned during an AC-3 call
+        /**
+         * for these two functions below, each layer corresponds to one call to AC-3 algorithm, top layer corresponds to most recent AC-3 call
+         * 
+         * @note why only ac3_pruned_nodes used to restore trie structure:
+         * ---
+         * after calls to remove_matching_words(), all the nodes removed from the trie are the nodes of 0 or more trees which 
+         * are branches chopped off of the original trie. thus, if a node has been removed from the main trie, it is guaranteed 
+         * that its connection, an edge from its parent node to itself, has been removed. vice versa, if a node's connection to its 
+         * child node has been removed, by the description of the behavior of remove_matching_words(), it is guaranteed that the 
+         * child node is no longer part of the trie. thus, the function from nodes removed from the trie to their parents from which 
+         * their incoming edge has been removed is one-to-one. therefore it is sufficient to store only a set of removed nodes since the 
+         * node datatype stores a weak_ptr to their parent which is not deleted in calls to remove_matching_words(). during the restore 
+         * call, we can simply restore all the removed nodes in the top layer of ac3_pruned_nodes, and for each node, access their parent 
+         * to restore the edge pointing to formerly removed node. 
+         * 
+         * note: overlap between the removed node set and parent node set is permitted iff all parent nodes (themselves removed or not) 
+         * remove edges to all their removed children, which indeed is the case. also notice that under these conditions, all the removed 
+         * nodes have no connections to one another
+        */
+        // contains nodes pruned during an AC-3 call
         stack<unordered_set<shared_ptr<trie_node> > > ac3_pruned_nodes; 
-        //   # of words pruned during an AC-3 call
+        // # of words pruned during an AC-3 call
         stack<size_t> ac3_pruned_words; 
-        //   map from node in nodes set -> parent node whose children map this node was removed from during an AC-3 call
-        stack<unordered_map<shared_ptr<trie_node>, shared_ptr<trie_node> > > ac3_pruned_children;
 
         // base constructor
         letters_table_entry() : num_words(0) {}

--- a/src/cw_trie/cw_trie_data_types.h
+++ b/src/cw_trie/cw_trie_data_types.h
@@ -43,6 +43,15 @@ namespace cw_trie_data_types_ns {
         // after remove_matching_words() is called, ptrs to nodes are still kept here as a backup and can be restored if needed
         unordered_set<shared_ptr<trie_node> > nodes;
 
+        // for these fields below, each layer corresponds to one call to AC-3 algorithm
+        // top layer corresponds to most recent AC-3 call
+        //   contains nodes pruned during an AC-3 call
+        stack<unordered_set<shared_ptr<trie_node> > > ac3_pruned_nodes; 
+        //   # of words pruned during an AC-3 call
+        stack<size_t> ac3_pruned_words; 
+        //   map from node in nodes set -> parent node whose children map this node was removed from during an AC-3 call
+        stack<unordered_map<shared_ptr<trie_node>, shared_ptr<trie_node> > > ac3_pruned_children;
+
         // base constructor
         letters_table_entry() : num_words(0) {}
     };

--- a/test/cw_csp/cw_csp_test_driver.cpp
+++ b/test/cw_csp/cw_csp_test_driver.cpp
@@ -158,7 +158,7 @@ bool cw_csp_test_driver::test_backtracking_validity(uint length, uint height, st
     dut = new cw_csp(dut_name.str(), length, height, contents, filepath);
     stringstream cw_result;
 
-    bool result = check_condition(dut_name.str() + " backtracking validity", dut->solve(BACKTRACKING, MIN_REMAINING_VALUES, false) == expected_result);
+    bool result = check_condition(dut_name.str() + " backtracking validity", dut->solve(BACKTRACKING, MIN_REMAINING_VALUES) == expected_result);
     if(result && expected_result && do_print) {
         cw_result << dut->result();
         utils->print_msg(&cw_result, DEBUG);

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -194,7 +194,7 @@ TEST_CASE("cw_trie remove_matching_words-letters_at_indicies", "[cw_trie],[quick
     num_nodes_ground_truths.push_back(num_nodes);
 
     REQUIRE(driver->test_letters_at_indicies_remove(init_words, remove_params, init_num_words, init_num_nodes, num_words_ground_truths, num_nodes_ground_truths));
-    REQUIRE(driver->test_word_map_empty());
+    REQUIRE(driver->test_domain_empty());
 }
 
 /**

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -352,10 +352,129 @@ TEST_CASE("cw_trie assigning-basic", "[cw_trie],[quick]") {
 }
 
 /**
- * more complex test mixing adding, removing, and assigning
+ * more complex test mixing adding, removing, and assigning in an AC-3 step
 */
-TEST_CASE("cw_trie adding_removing_assigning", "[cw_trie],[quick]") {
-    REQUIRE(true);
+TEST_CASE("cw_trie adding_removing_assigning", "[cw_trie]") {
+    shared_ptr<cw_trie_test_driver> driver = make_shared<cw_trie_test_driver>("cw_trie_test_driver-adding_removing_assigning");
+
+    // for this test, add every possible 4 letter word composed of only the first 20 letters of alphabet
+    vector<word_t> init_words;
+    for(char c0 = 'a'; c0 <= 't'; c0++) {
+        for(char c1 = 'a'; c1 <= 't'; c1++) {
+            for(char c2 = 'a'; c2 <= 't'; c2++) {
+                for(char c3 = 'a'; c3 <= 't'; c3++) {
+                    string word = {c0, c1, c2, c3};
+                    init_words.push_back(word_t(word));
+                }
+            }
+        }
+    }
+    driver->add_words(init_words);
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> init_num_words = {{
+        //   a     b     c     d     e     f     g     h     i     j     k     l     m     n     o     p     q     r     s     t     u     v     w     x     y     z
+        { 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,    0,    0,    0,    0,    0,    0},
+        { 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,    0,    0,    0,    0,    0,    0},
+        { 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,    0,    0,    0,    0,    0,    0},
+        { 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,    0,    0,    0,    0,    0,    0},
+    }};
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> init_num_nodes = {{
+        //   a     b     c     d     e     f     g     h     i     j     k     l     m     n     o     p     q     r     s     t     u     v     w     x     y     z
+        {    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    1,    0,    0,    0,    0,    0,    0},
+        {   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,   20,    0,    0,    0,    0,    0,    0},
+        {  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,  400,    0,    0,    0,    0,    0,    0},
+        { 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000, 8000,    0,    0,    0,    0,    0,    0},
+    }};
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> num_words = init_num_words;
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> num_nodes = init_num_nodes;
+    vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_words_ground_truths;
+    vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_nodes_ground_truths;
+    vector<pair<uint, char> > remove_params;
+    uint num_words_remaining = static_cast<uint>(init_words.size());
+    uint factor;
+
+    REQUIRE(driver->test_letters_at_indicies_add({}, num_words, num_nodes, {}, {}));
+    REQUIRE(driver->test_letters_at_indicies_row_sums(num_words, 4, num_words_remaining));
+
+    init_num_words = num_words;
+    init_num_nodes = num_nodes;
+    num_words_ground_truths.clear();
+    num_nodes_ground_truths.clear();    
+
+    // --------------- remove a @ 0 ---------------
+
+    remove_params.push_back({0, 'a'});
+    num_words_remaining -= 8000;
+
+    for(uint i = 1; i < 4; i++) for(uint j = 0; j < 20; j++) num_words[i][j] -= 400;
+    num_words[0][0] = 0; 
+    num_words_ground_truths.push_back(num_words);
+
+    factor = 1;
+    for(uint i = 1; i < 4; i++) { for(uint j = 0; j < 20; j++) { num_nodes[i][j] -= factor; } factor *= 20; }
+    num_nodes[0][0] = 0;
+    num_nodes_ground_truths.push_back(num_nodes);
+
+    // --------------- remove b @ 0 ---------------
+
+    remove_params.push_back({0, 'b'});
+    num_words_remaining -= 8000;
+
+    for(uint i = 1; i < 4; i++) for(uint j = 0; j < 20; j++) num_words[i][j] -= 400;
+    num_words[0][1] = 0; 
+    num_words_ground_truths.push_back(num_words);
+
+    factor = 1;
+    for(uint i = 1; i < 4; i++) { for(uint j = 0; j < 20; j++) { num_nodes[i][j] -= factor; } factor *= 20; }
+    num_nodes[0][1] = 0;
+    num_nodes_ground_truths.push_back(num_nodes);
+
+    // --------------- remove c @ 1 ---------------
+
+    remove_params.push_back({1, 'c'});
+    num_words_remaining -= 400 * 18;
+
+    for(uint j = 2; j < 20; j++) num_words[0][j] -= 20 * 20; // excluding 'a' and 'b' @ index 0 since those are already removed
+    for(uint i = 2; i < 4; i++) for(uint j = 0; j < 20; j++) num_words[i][j] -= 18 * 20;
+    num_words[1][2] = 0; 
+    num_words_ground_truths.push_back(num_words);
+
+    factor = 18;
+    for(uint i = 2; i < 4; i++) { for(uint j = 0; j < 20; j++) { num_nodes[i][j] -= factor; } factor *= 20; }
+    num_nodes[1][2] = 0;
+    num_nodes_ground_truths.push_back(num_nodes);
+
+    // --------------- remove d @ 2 ---------------
+
+    remove_params.push_back({2, 'd'});
+    num_words_remaining -= 20 * 19 * 18;
+
+    for(uint j = 2; j < 20; j++) num_words[0][j] -= 20 * 19; // excluding 'a' and 'b' @ index 0 since those are already removed
+    for(uint j = 0; j < 20; j++) if(j != 2) num_words[1][j] -= 20 * 18;
+    for(uint j = 0; j < 20; j++) num_words[3][j] -= 19 * 18;
+    num_words[2][3] = 0; 
+    num_words_ground_truths.push_back(num_words);
+
+    factor = 19 * 18;
+    for(uint j = 0; j < 20; j++) { num_nodes[3][j] -= factor; }
+    num_nodes[2][3] = 0;
+    num_nodes_ground_truths.push_back(num_nodes);
+
+    // --------------- remove a @ 3 ---------------
+
+    remove_params.push_back({3, 'a'});
+    num_words_remaining -= 19 * 19 * 18;
+
+    for(uint j = 2; j < 20; j++) num_words[0][j] -= 19 * 19; // excluding 'a' and 'b' @ index 0 since those are already removed
+    for(uint j = 0; j < 20; j++) if(j != 2) num_words[1][j] -= 19 * 18;
+    for(uint j = 0; j < 20; j++) if(j != 3) num_words[2][j] -= 19 * 18;
+    num_words[3][0] = 0;
+    num_words_ground_truths.push_back(num_words);
+
+    num_nodes[3][0] = 0;
+    num_nodes_ground_truths.push_back(num_nodes);
+
+    REQUIRE(driver->test_letters_at_indicies_remove_assign({}, remove_params, init_num_words, init_num_nodes, num_words_ground_truths, num_nodes_ground_truths));
+    REQUIRE(driver->test_letters_at_indicies_row_sums(num_words, 4, num_words_remaining));
 }
 
 // TODO: add test case with word of max length

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -357,3 +357,5 @@ TEST_CASE("cw_trie assigning-basic", "[cw_trie],[quick]") {
 TEST_CASE("cw_trie adding_removing_assigning", "[cw_trie],[quick]") {
     REQUIRE(true);
 }
+
+// TODO: add test case with word of max length

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -360,4 +360,6 @@ TEST_CASE("cw_trie adding_removing_assigning", "[cw_trie],[quick]") {
 
 // TODO: add test case with word of max length
 
-// TODO: add test for letters_at_index
+// TODO: add test for get_all_letters_at_index 
+
+// TODO: add test with empty AC-3 step

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -480,7 +480,7 @@ TEST_CASE("cw_trie adding_removing_assigning-letters_at_indicies", "[cw_trie]") 
 /**
  * removing and assigning test with words of max length
 */
-TEST_CASE("cw_trie remove_matching_words-max_length-letters_at_indicies", "[cw_trie]") {
+TEST_CASE("cw_trie remove_matching_words-max_length-letters_at_indicies", "[cw_trie],[slow]") {
     shared_ptr<cw_trie_test_driver> driver = make_shared<cw_trie_test_driver>("cw_trie_test_driver-remove_matching_words-max_length-letters_at_indicies");
 
     assert_m(MAX_WORD_LEN <= 32, "value of MAX_WORD_LEN exceeds bit width, update test");

--- a/test/cw_trie/cw_trie_test.cpp
+++ b/test/cw_trie/cw_trie_test.cpp
@@ -359,3 +359,5 @@ TEST_CASE("cw_trie adding_removing_assigning", "[cw_trie],[quick]") {
 }
 
 // TODO: add test case with word of max length
+
+// TODO: add test for letters_at_index

--- a/test/cw_trie/cw_trie_test_driver.cpp
+++ b/test/cw_trie/cw_trie_test_driver.cpp
@@ -129,19 +129,16 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove(
     result &= check_condition("letters_at_indicies initial num_words", letters_at_indicies_entries_equal(initial_num_words, letters_at_indices, true));
     result &= check_condition("letters_at_indicies initial num nodes", letters_at_indicies_entries_equal(initial_num_nodes, letters_at_indices, false));
 
-    unordered_set<word_t> pruned_words;
     const size_t init_domain_size = dut->get_word_map().size();
     size_t num_removed = 0;
 
     // iterate twice to ensure AC-3 restoration works properly
     for(uint iteration = 0; iteration < 2; iteration++) {
-        pruned_words.clear();
         for(uint i = 0; i < remove_params.size(); i++) {
             dut->start_new_ac3_call(); // simulate single AC-3 layer for each remove
-            num_removed += dut->remove_matching_words(pruned_words, remove_params[i].first, remove_params[i].second);
+            num_removed += dut->remove_matching_words(remove_params[i].first, remove_params[i].second);
             letters_at_indices = dut->get_letters_at_indices();
 
-            result &= check_condition("num_removed equal to pruned_words size", num_removed == pruned_words.size());
             result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
             result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
             result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());
@@ -168,13 +165,11 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove(
     }
 
     // remove again
-    pruned_words.clear();
     for(uint i = 0; i < remove_params.size(); i++) {
         dut->start_new_ac3_call(); // simulate single AC-3 layer for each remove
-        num_removed += dut->remove_matching_words(pruned_words, remove_params[i].first, remove_params[i].second);
+        num_removed += dut->remove_matching_words(remove_params[i].first, remove_params[i].second);
         letters_at_indices = dut->get_letters_at_indices();
 
-        result &= check_condition("num_removed nonequal to pruned_words size", num_removed == pruned_words.size());
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
         result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());

--- a/test/cw_trie/cw_trie_test_driver.cpp
+++ b/test/cw_trie/cw_trie_test_driver.cpp
@@ -35,8 +35,7 @@ cw_trie_test_driver::cw_trie_test_driver(string name, string filepath) : common_
  * @return true iff successful
 */
 bool cw_trie_test_driver::test_trie_basic(string pattern, unordered_set<word_t>& ground_truth) {
-    unordered_set<word_t> result;
-    dut->find_matches(result, pattern);
+    unordered_set<word_t> result = dut->find_matches(pattern);
 
     ss << "actual output: ";
     for(word_t w : result) ss << w.word << ", ";

--- a/test/cw_trie/cw_trie_test_driver.cpp
+++ b/test/cw_trie/cw_trie_test_driver.cpp
@@ -36,11 +36,6 @@ cw_trie_test_driver::cw_trie_test_driver(string name, string filepath) : common_
 */
 bool cw_trie_test_driver::test_trie_basic(string pattern, unordered_set<word_t>& ground_truth) {
     unordered_set<word_t> result = dut->find_matches(pattern);
-
-    ss << "actual output: ";
-    for(word_t w : result) ss << w.word << ", ";
-    utils->print_msg(&ss, DEBUG);
-
     return check_condition("find_matches for \"" + pattern + "\"", set_contents_equal(&ground_truth, &result, true));
 }
 
@@ -95,10 +90,6 @@ bool cw_trie_test_driver::test_letters_at_indicies_row_sums(
 ) {
     bool result = true;
     for(uint i = 0; i < word_len; i++) {
-        if(!(std::accumulate(std::begin(num_words[i]), std::end(num_words[i]), 0u) == total_words)) {
-            ss << "sum: " << std::accumulate(std::begin(num_words[i]), std::end(num_words[i]), 0u) << ", total_words: " << total_words;
-            utils->print_msg(&ss, INFO);
-        }
         result &= check_condition("letters_at_indicies row sum", std::accumulate(std::begin(num_words[i]), std::end(num_words[i]), 0u) == total_words);
     }
 
@@ -187,6 +178,7 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove(
  * 
  * @param init_words words to add at once before removal calls
  * @param remove_params words to remove, in order, size must be equal to num_words_ground_truths, num_nodes_ground_truths
+ * @param last_remaining if has value, expected singular domain value remaining after removes
  * @param initial_num_words initial state of num_words in letters_at_indices
  * @param initial_num_nodes initial state of nodes.size() in letters_at_indices
  * @param num_words_ground_truths expected num_words after each call to remove_matching_words(), size must be equal as remove_params, num_nodes_ground_truths
@@ -194,7 +186,7 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove(
  * @returns true iff letters_at_indices equal to expected at every step 
 */
 bool cw_trie_test_driver::test_letters_at_indicies_remove_assign(
-    vector<word_t> init_words, vector<pair<uint, char> > remove_params, 
+    vector<word_t> init_words, vector<pair<uint, char> > remove_params, optional<word_t> last_remaining, 
     array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_words,
     array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_nodes,
     vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_words_ground_truths,
@@ -223,6 +215,12 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove_assign(
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
         result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());
+    }
+
+    if(last_remaining.has_value()) {
+        vector<word_t> remaining_domain = dut->get_cur_domain();
+        result &= remaining_domain.size() == 1;
+        result &= remaining_domain[0] == last_remaining.value();
     }
     
     dut->start_new_ac3_call(); // dummy blank layer
@@ -258,6 +256,122 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove_assign(
     result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(initial_num_nodes, letters_at_indices, false));
     result &= check_condition("num_removed is 0 after undoing all removes", num_removed == 0);
     result &= check_condition("domain size preserved during restore to init", init_domain_size == dut->get_word_map().size());
+
+    return result;
+}
+
+/**
+ * @brief directed test for get_all_letters_at_index() return vals after add/remove calls and during assignment in multiple AC-3 steps
+ * 
+ * @param words words to add first
+ * @param remove_params words to remove, in order
+ * @param initial_num_words initial state of num_words in letters_at_indices
+ * @returns true iff get_all_letters_at_index() returns expected value at every step
+*/
+bool cw_trie_test_driver::test_get_all_letters_at_index(
+    vector<word_t> words, vector<pair<uint, char> > remove_params, 
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_words
+) {
+    bool result = true;
+
+    array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> num_words = initial_num_words;
+    array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> letters_at_indices = dut->get_letters_at_indices();
+    unordered_set<char> expected, actual;
+
+    result &= check_condition("letters_at_indicies initial num_words", letters_at_indicies_entries_equal(initial_num_words, letters_at_indices, true));
+
+    // check initial return result
+    for(uint i = 0; i < MAX_WORD_LEN; i++) {
+        expected = get_all_letters_at_index(i, num_words);
+        actual = dut->get_all_letters_at_index(i);
+        result &= set_contents_equal(&expected, &actual, false);
+    }
+
+    // add words
+    for(word_t word : words) {
+        
+        dut->add_word(word);
+        for(size_t i = 0; i < word.word.size(); i++) {
+            num_words[i][static_cast<size_t>(word.word.at(i) - 'a')] += 1;
+        }
+
+        letters_at_indices = dut->get_letters_at_indices();
+        result &= check_condition("letters_at_indicies num_words add", letters_at_indicies_entries_equal(num_words, letters_at_indices, true));
+
+        // check return result
+        for(uint i = 0; i < MAX_WORD_LEN; i++) {
+            expected = get_all_letters_at_index(i, num_words);
+            actual = dut->get_all_letters_at_index(i);
+            result &= set_contents_equal(&expected, &actual, false);
+        }
+    }
+
+    dut->start_new_ac3_call(); // simulate single AC-3 layer for all assignments
+
+    // try assigning candidates
+    vector<word_t> candidates = dut->get_cur_domain();
+    result &= candidates.size() == dut->domain_size();
+    for(word_t candidate : candidates) {
+        dut->assign_domain(candidate);
+        
+        // check return result
+        for(uint i = 0; i < candidate.word.size(); i++) {
+            expected = { candidate.word.at(i) };
+            actual = dut->get_all_letters_at_index(i);
+            result &= set_contents_equal(&expected, &actual, false);
+        }
+
+        dut->remove_matching_words(0, candidate.word.at(0));
+    }
+
+    result &= dut->undo_prev_ac3_call() == 1; 
+    dut->unassign_domain();
+
+    unordered_set<word_t> words_remaining(words.begin(), words.end());
+
+    dut->start_new_ac3_call(); // simulate single AC-3 layer for all removes
+
+    // execute removes
+    for(uint i = 0; i < remove_params.size(); i++) {
+        
+        unordered_set<word_t> removed;
+        for(word_t word : words_remaining) {
+            if(word.word.at(remove_params[i].first) == remove_params[i].second) {
+                removed.insert(word);
+                for(uint j = 0; j < word.word.size(); j++) {
+                    num_words[j][static_cast<size_t>(word.word.at(j) - 'a')] -= 1;
+                }
+            }
+        }
+        for(word_t word : removed) words_remaining.erase(word);
+
+        dut->remove_matching_words(remove_params[i].first, remove_params[i].second);
+        letters_at_indices = dut->get_letters_at_indices();
+        result &= check_condition("letters_at_indicies num_words remove", letters_at_indicies_entries_equal(num_words, letters_at_indices, true));
+
+        // check return result
+        for(uint j = 0; j < MAX_WORD_LEN; j++) {
+            expected = get_all_letters_at_index(j, num_words);
+            actual = dut->get_all_letters_at_index(j);
+            result &= set_contents_equal(&expected, &actual, false);
+        }
+    }
+
+    // try assigning candidates, again
+    candidates = dut->get_cur_domain();
+    result &= candidates.size() == dut->domain_size();
+    for(word_t candidate : candidates) {
+        dut->assign_domain(candidate);
+        
+        // check return result
+        for(uint i = 0; i < candidate.word.size(); i++) {
+            expected = { candidate.word.at(i) };
+            actual = dut->get_all_letters_at_index(i);
+            result &= set_contents_equal(&expected, &actual, false);
+        }
+
+        dut->remove_matching_words(0, candidate.word.at(0));
+    }
 
     return result;
 }
@@ -312,4 +426,24 @@ bool cw_trie_test_driver::letters_at_indicies_entries_equal(
         }
     }
     return result;
+}
+
+/**
+ * @brief helper for test_get_all_letters_at_index() to generate expected result
+ * 
+ * @param index the index of the table to consider
+ * @param num_words ref to num word table to generate result from
+ * @returns set of all letters with at least 1 appearance at specified index
+ * 
+*/
+unordered_set<char> cw_trie_test_driver::get_all_letters_at_index(uint index, array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN>& num_words) {
+    assert_m(index < MAX_WORD_LEN, "index exceeds table dimension");
+
+    unordered_set<char> expected;
+    for(uint i = 0; i < NUM_ENGLISH_LETTERS; i++) {
+        if(num_words[index][i] > 0) {
+            expected.insert(static_cast<char>('a' + i));
+        }
+    }
+    return expected;
 }

--- a/test/cw_trie/cw_trie_test_driver.cpp
+++ b/test/cw_trie/cw_trie_test_driver.cpp
@@ -131,13 +131,16 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove(
 
     unordered_set<word_t> pruned_words;
     const size_t init_word_map_size = dut->get_word_map().size();
+    size_t num_removed = 0;
     for(uint i = 0; i < remove_params.size(); i++) {
-        dut->remove_matching_words(pruned_words, remove_params[i].first, remove_params[i].second);
+        dut->start_new_ac3_call(); // simulate single AC-3 layer for each remove
+        num_removed += dut->remove_matching_words(pruned_words, remove_params[i].first, remove_params[i].second);
         letters_at_indices = dut->get_letters_at_indices();
 
+        result &= check_condition("num_removed nonequal to pruned_words size", num_removed == pruned_words.size());
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
-        result &= check_condition("word_map size preserved", init_word_map_size == pruned_words.size() + dut->get_word_map().size());
+        result &= check_condition("word_map size preserved", init_word_map_size == num_removed + dut->get_word_map().size());
     }
 
     return result;

--- a/test/cw_trie/cw_trie_test_driver.cpp
+++ b/test/cw_trie/cw_trie_test_driver.cpp
@@ -230,6 +230,7 @@ bool cw_trie_test_driver::test_letters_at_indicies_remove_assign(
 
     // try assigning candidates
     vector<word_t> candidates = dut->get_cur_domain();
+    result &= candidates.size() == dut->domain_size();
     for(word_t candidate : candidates) {
         dut->assign_domain(candidate);
         result &= test_num_letters_at_indicies_assign(candidate);

--- a/test/cw_trie/cw_trie_test_driver.h
+++ b/test/cw_trie/cw_trie_test_driver.h
@@ -60,8 +60,8 @@ namespace cw_trie_test_driver_ns {
 
             // expose basic functionalities for dut 
             void add_words(vector<word_t> words) { for(word_t w : words) dut->add_word(w); }
-            void remove_words(unordered_set<word_t>& pruned_words, vector<pair<uint, char> > remove_params) { 
-                for(const auto& pair : remove_params) dut->remove_matching_words(pruned_words, pair.first, pair.second);
+            void remove_words(vector<pair<uint, char> > remove_params) { 
+                for(const auto& pair : remove_params) dut->remove_matching_words(pair.first, pair.second);
             }
             void assign_domain(word_t word) { dut->assign_domain(word); }
             void unassign_domain() { dut->unassign_domain(); }

--- a/test/cw_trie/cw_trie_test_driver.h
+++ b/test/cw_trie/cw_trie_test_driver.h
@@ -54,11 +54,17 @@ namespace cw_trie_test_driver_ns {
 
             // directed test for letters_at_indicies state after remove calls and during assignment in an AC-3 step
             bool test_letters_at_indicies_remove_assign(
-                vector<word_t> init_words, vector<pair<uint, char> > remove_params, 
+                vector<word_t> init_words, vector<pair<uint, char> > remove_params, optional<word_t> last_remaining, 
                 array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_words,
                 array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_nodes,
                 vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_words_ground_truths,
                 vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_nodes_ground_truths
+            );
+
+            // directed test for get_all_letters_at_index state after add, remove, and assign calls
+            bool test_get_all_letters_at_index(
+                vector<word_t> words, vector<pair<uint, char> > remove_params, 
+                array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_words
             );
             
             // basic check after remove tests that the domain is empty
@@ -74,6 +80,7 @@ namespace cw_trie_test_driver_ns {
             }
             void assign_domain(word_t word) { dut->assign_domain(word); }
             void unassign_domain() { dut->unassign_domain(); }
+            vector<word_t> get_cur_domain() { return dut->get_cur_domain(); }
 
             // destructor, all objects are raii and should delete automatically
             ~cw_trie_test_driver() = default;
@@ -87,6 +94,11 @@ namespace cw_trie_test_driver_ns {
                 array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> expected,
                 array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> ground_truth,
                 bool test_num_words
+            );
+
+            // helper function for test_get_all_letters_at_index()
+            unordered_set<char> get_all_letters_at_index(
+                uint index, array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN>& num_words
             );
     }; // cw_trie_test_driver
 } // cw_trie_test_driver_ns

--- a/test/cw_trie/cw_trie_test_driver.h
+++ b/test/cw_trie/cw_trie_test_driver.h
@@ -52,8 +52,8 @@ namespace cw_trie_test_driver_ns {
                 vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_nodes_ground_truths
             );
             
-            // basic check after remove tests that word_map is empty
-            bool test_word_map_empty() { return dut->get_word_map().size() == 0; }
+            // basic check after remove tests that the domain is empty
+            bool test_domain_empty() { return dut->domain_size() == 0; }
 
             // basic directed test for num_letters_at_index() after assigning domain
             bool test_num_letters_at_indicies_assign(word_t value);

--- a/test/cw_trie/cw_trie_test_driver.h
+++ b/test/cw_trie/cw_trie_test_driver.h
@@ -51,6 +51,15 @@ namespace cw_trie_test_driver_ns {
                 vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_words_ground_truths,
                 vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_nodes_ground_truths
             );
+
+            // directed test for letters_at_indicies state after remove calls and during assignment in an AC-3 step
+            bool test_letters_at_indicies_remove_assign(
+                vector<word_t> init_words, vector<pair<uint, char> > remove_params, 
+                array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_words,
+                array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> initial_num_nodes,
+                vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_words_ground_truths,
+                vector<array<array<uint, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> > num_nodes_ground_truths
+            );
             
             // basic check after remove tests that the domain is empty
             bool test_domain_empty() { return dut->domain_size() == 0; }


### PR DESCRIPTION
## Overview
- add AC-3 call tracking and undoing to `cw_trie`
- add minor miscellaneous helper functions for AC-3 calls to `cw_trie` 
- add support for `progress_bar` display to `cw_trie`

## Details
- the core implementation is in two new functions in `cw_trie`, called `start_new_ac3_call()` and `undo_prev_ac3_call()`. in `letters_at_indicies`, two stacks have been added to each element to track the number of words pruned during an AC-3 call and the corresponding nodes. upon each new AC-3 call, the first function should be called, which pushes a new layer to each stack. when `undo_ac3()` is eventually called in `cw_csp`, `undo_prev_ac3_call()` should be called, which will pop from each stack and restore the nodes and word counts back to `letters_at_indicies`. 
- runtime complexity of removing and un-removing words from `cw_trie` depends on the nodes being operated on and thus is now `O(n)` with respect to the number of words. however, these operate on pointers instead of expensive strings and thus should be a significant speedup, in addition to now having `O(1)` space complexity
- with an AC-3 iteration now being `O(1)` best case if no words are pruned, this should speed up crossword generation by a large amount
- a progress bar is now also displayed (in addition to the searching progress bar) during `cw_trie` construction execution with a label of "Building Dictionary" if a progress bar is enabled in the CLI

## Testing
- existing test suite all passes
- add tests related to AC-3 calls to `cw_trie`. one of these tests uses every possible max length word composed of `'a'`s or `'b'`s and is very slow, but has been labeled with a new Catch2 test tag, `[slow]`
- update existing `cw_trie` test suite to include tests of AC-3 call undoing

## Notes
- renaming of `cw_trie`, mentioned in #21, is still unresolved
- completes implementation but not integration of #15 into the main codeflow
- during experimentation, #23 was discovered, and should be fixed in a future PR. unclear if it is related to the content in this PR