### PR TITLE
Integration of AC-3 Optimization

### DIFF
--- a/src/common/common_parent.cpp
+++ b/src/common/common_parent.cpp
@@ -26,6 +26,7 @@ common_parent::common_parent(string name) {
 */
 bool common_parent::check_condition(string name, bool condition) {
     if(!condition) {
+        stringstream ss;
         ss << "failed condition: " << name;
         utils->print_msg(&ss, WARNING);
     }

--- a/src/common/common_parent.h
+++ b/src/common/common_parent.h
@@ -18,7 +18,6 @@ namespace common_parent_ns {
         public:
             string name;
             cw_utils* utils; // TODO: make this unique_ptr
-            stringstream ss;
 
             // base constructor
             common_parent(string name);

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -87,6 +87,7 @@ unordered_map<cw_variable, unordered_set<cw_constraint> > cw_csp::get_arc_depend
 */
 void cw_csp::initialize_csp() {
 
+    stringstream ss;
     ss << "cw_csp starting csp initialization";
     utils->print_msg(&ss, DEBUG);
 
@@ -317,6 +318,7 @@ void cw_csp::initialize_csp() {
 */
 bool cw_csp::ac3() {
 
+    stringstream ss;
     ss << "starting AC-3 algorithm";
     utils->print_msg(&ss, DEBUG);
 
@@ -502,6 +504,7 @@ void cw_csp::overwrite_cw() {
                     }
                 }
             } else {
+                stringstream ss;
                 ss << "got unknown direction type: " << var_ptr->dir;
                 utils->print_msg(&ss, ERROR);
             }
@@ -573,6 +576,7 @@ bool cw_csp::solve(csp_solving_strategy csp_strategy, var_selection_method var_s
                 return solve_backtracking(var_strategy, print_progress_bar);
             } break;
         default: {
+                stringstream ss;
                 ss << "solve() got unknown strategy";
                 utils->print_msg(&ss, ERROR);
                 return false;
@@ -591,6 +595,7 @@ bool cw_csp::solve(csp_solving_strategy csp_strategy, var_selection_method var_s
 */
 bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool do_progress_bar) {
 
+    stringstream ss;
     ss << "entering solve_backtracking() with cw: " << cw;
     utils->print_msg(&ss, DEBUG);
 

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -329,10 +329,6 @@ bool cw_csp::ac3() {
     // a constraint c is in constraints_in_queue iff c also in constraint_queue
     unordered_set<shared_ptr<cw_constraint> > constraints_in_queue;
 
-    // map from variable --> words pruned from its domain
-    // tracks pruned words to undo AC-3 if resulting CSP is invalid
-    // unordered_map<shared_ptr<cw_variable>, unordered_set<word_t> > pruned_domains;
-
     // notify var domains of new AC-3 call
     for(shared_ptr<cw_variable> var_ptr : variables) {
         var_ptr->domain.start_new_ac3_call();
@@ -354,28 +350,13 @@ bool cw_csp::ac3() {
         assert(constraints_in_queue.count(constr) > 0);
         constraints_in_queue.erase(constr);
 
-        // prune invalid words in domain
-        // pruned_words = constr->prune_domain();
-
-        // track pruned words for each var in case undo is needed if CSP becomes invalid
-        // for(word_t pruned_word : pruned_words) {
-        //     pruned_domains[constr->lhs].insert(pruned_word);
-        // }
-        
-        // if domain was changed while pruning, add dependent arcs to constraint queue
-
         // prune invalid words in domain, and if domain changed, add dependent arcs to constraint queue
         if(constr->prune_domain()) {
-        // if(pruned_words.size() > 0) {
             if(constr->lhs->domain.size() == 0) {
-            // if(constr->lhs->domain.size() == 0) {
                 // CSP is now invalid, i.e. var has empty domain
             
                 ss << "CSP became invalid, undo-ing pruning";
                 utils->print_msg(&ss, DEBUG);
-
-                // save record of all domain values pruned
-                // prev_pruned_domains.push(pruned_domains);
 
                 // undo pruning
                 undo_ac3();
@@ -392,9 +373,6 @@ bool cw_csp::ac3() {
         }
     }
 
-    // save record of all domain values pruned
-    // prev_pruned_domains.push(pruned_domains);
-
     // running AC-3 to completion does not make CSP invalid
     return true;
 }
@@ -403,16 +381,6 @@ bool cw_csp::ac3() {
  * @brief undo domain pruning from previous call of AC-3 algorithm
 */
 void cw_csp::undo_ac3() {
-    // assert(prev_pruned_domains.size() > 0);
-
-    // for(const auto& pair : prev_pruned_domains.top()) {
-    //     // re-add pruned words
-    //     for(word_t pruned_word : pair.second) {
-    //         pair.first->domain.insert(pruned_word);
-    //     }
-    // }
-    // prev_pruned_domains.pop();
-
     for(shared_ptr<cw_variable> var_ptr : variables) {
         var_ptr->domain.undo_prev_ac3_call();
     }
@@ -622,7 +590,6 @@ bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool do_progr
     }
 
     // search all possible values, sorted by word score, tiebroken by frequency
-    // vector<word_t> domain_copy(next_var->domain.begin(), next_var->domain.end());
     vector<word_t> domain_copy = next_var->domain.get_cur_domain();
     auto compare = [](const word_t& lhs, const word_t& rhs) {
         if(lhs.score != rhs.score) return lhs.score > rhs.score;
@@ -642,7 +609,6 @@ bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool do_progr
         // avoid duplicate words
         if(assigned_words.count(word) == 0) {
             // assignment
-            // next_var->domain = {word}; // TODO: perhaps use std::swap here
             next_var->domain.assign_domain(word);
             next_var->assigned = true;
             assigned_words.insert(word);

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -86,9 +86,6 @@ namespace cw_csp_ns {
             // arc_dependencies[var_i] contains ptrs to all arcs of the form (var_k, var_i) 
             unordered_map<shared_ptr<cw_variable>, unordered_set<shared_ptr<cw_constraint> > > arc_dependencies;
 
-            // previous domain pruned from each variable during calls to ac3()
-            // stack<unordered_map<shared_ptr<cw_variable>, unordered_set<word_t> > > prev_pruned_domains;
-
             // previous cw tile values overwritten during call to overwrite_cw(), used for undo_overwrite_cw()
             stack<vector<tuple<char, uint, uint> > > prev_overwritten_tiles; 
 

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -87,7 +87,7 @@ namespace cw_csp_ns {
             unordered_map<shared_ptr<cw_variable>, unordered_set<shared_ptr<cw_constraint> > > arc_dependencies;
 
             // previous domain pruned from each variable during calls to ac3()
-            stack<unordered_map<shared_ptr<cw_variable>, unordered_set<word_t> > > prev_pruned_domains;
+            // stack<unordered_map<shared_ptr<cw_variable>, unordered_set<word_t> > > prev_pruned_domains;
 
             // previous cw tile values overwritten during call to overwrite_cw(), used for undo_overwrite_cw()
             stack<vector<tuple<char, uint, uint> > > prev_overwritten_tiles; 

--- a/src/cw_csp/cw_csp_data_types.cpp
+++ b/src/cw_csp/cw_csp_data_types.cpp
@@ -99,30 +99,6 @@ cw_variable::cw_variable(uint origin_row, uint origin_col, uint length, word_dir
     // do nothing, delegated to constructor that does everything needed
 }
 
-/**
- * @brief tests if this var contains a word that satisifes one cw equality constraint and isn't the same word
- * @param param_word the other word to compare to
- * @param param_letter_pos index of the letter in param_word that this domain must contain
- * @param letter_pos the index at which the letter must appear in the word
- * @return true iff this var contains 1+ word in its domain that contains letter at position letter_pos
-*/
-// bool cw_variable::can_satisfy_constraint(const string& param_word, const uint& param_letter_pos, const uint& letter_pos) const {
-
-//     stringstream ss;
-//     cw_utils* utils = new cw_utils("satisfies_constraint()", VERBOSITY);
-    
-//     if(param_word.at(param_letter_pos) < 'a' || param_word.at(param_letter_pos) > 'z') {
-//         ss << "unknown target letter: " << param_word.at(param_letter_pos);
-//         utils->print_msg(&ss, ERROR);
-//     }
-
-//     for(word_t w : domain) {
-//         if(w.word != param_word && w.word.at(letter_pos) == param_word.at(param_letter_pos)) return true;
-//     }
-
-//     return false;
-// }
-
 // ############### cw_constraint ###############
 
 /**
@@ -172,20 +148,6 @@ cw_constraint::cw_constraint(uint lhs_index, uint rhs_index, shared_ptr<cw_varia
  * @return true iff 1 or more words pruned, i.e. domain changed
 */
 bool cw_constraint::prune_domain() {
-
-    // // find words to prune from domain
-    // unordered_set<word_t> pruned_words;
-    // for(word_t w : lhs->domain) {
-    //     if(!rhs->can_satisfy_constraint(w.word, lhs_index, rhs_index)) {
-    //         // queue word to be removed from lhs domain
-    //         pruned_words.insert(w);
-    //     }
-    // }
-
-    // // remove words
-    // for(word_t w : pruned_words) lhs->domain.erase(w);
-
-    // return pruned_words;
 
     size_t num_removed = 0;
     for(char letter : lhs->domain.get_all_letters_at_index(lhs_index)) {

--- a/src/cw_csp/cw_csp_data_types.cpp
+++ b/src/cw_csp/cw_csp_data_types.cpp
@@ -57,7 +57,7 @@ size_t hash<cw_variable>::operator()(const cw_variable& var) const {
 ostream& cw_csp_data_types_ns::operator<<(ostream& os, const cw_variable& var) {
     os << "row: " << var.origin_row << ", col: " << var.origin_col << ", len: " << var.length
        << ", dir: " << cw_csp_data_types_ns::word_dir_name.at(var.dir) << ", pattern: " 
-       << var.pattern << ", assigned: " << var.assigned << ", domain: {";
+       << var.pattern << ", domain: {";
     for(word_t w : var.domain.get_cur_domain()) {
         os << w.word << ", ";
     }

--- a/src/cw_csp/cw_csp_data_types.h
+++ b/src/cw_csp/cw_csp_data_types.h
@@ -41,13 +41,13 @@ namespace cw_csp_data_types_ns {
 
     // a variable in a constraint satisfaction problem
     struct cw_variable {
-        uint origin_row;              // 0-indexed
-        uint origin_col;              // 0-indexed
-        uint length;                  // >= 0
-        word_direction dir;           // direction of word of this var
-        string pattern;               // original pattern used to populate domain
-        unordered_set<word_t> domain; // all possible words that fit
-        bool assigned = false;        // true iff assigned to single value --> domain.size() == 1
+        uint origin_row;       // 0-indexed
+        uint origin_col;       // 0-indexed
+        uint length;           // >= MIN_WORD_LEN && <= MAX_WORD_LEN
+        word_direction dir;    // direction of word of this var
+        string pattern;        // original pattern used to populate domain
+        word_domain domain;    // all possible words that fit
+        bool assigned = false; // true iff assigned to single value --> domain.size() == 1
 
         // standard constructor for cw_csp
         cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, unordered_set<word_t> domain);
@@ -56,10 +56,17 @@ namespace cw_csp_data_types_ns {
         cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, unordered_set<word_t> domain);
 
         // for AC-3 based CSP reduction
-        bool can_satisfy_constraint(const string& param_word, const uint& param_letter_pos, const uint& letter_pos) const;
+        // bool can_satisfy_constraint(const string& param_word, const uint& param_letter_pos, const uint& letter_pos) const;
         
         // equality operator, TODO: is this needed?
         bool operator==(const cw_variable& rhs) const;
+
+        // destructor
+        // ~cw_variable() = default;
+
+        // copy constructor
+
+        // copy assignment constructor
     };
 
     // operator to print out cw_variable for debug
@@ -80,7 +87,7 @@ namespace cw_csp_data_types_ns {
         cw_constraint(uint lhs_index, uint rhs_index, shared_ptr<cw_variable> lhs, shared_ptr<cw_variable> rhs);
 
         // AC-3 step; remove all words in lhs domain that don't have a corresponding rhs word in its domain
-        unordered_set<word_t> prune_domain(); 
+        bool prune_domain(); 
 
         // used by solved() in cw_csp to check that this constraint is satisfied
         bool satisfied() const;

--- a/src/cw_csp/cw_csp_data_types.h
+++ b/src/cw_csp/cw_csp_data_types.h
@@ -55,18 +55,8 @@ namespace cw_csp_data_types_ns {
         // testing-only constructor
         cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, unordered_set<word_t> domain);
 
-        // for AC-3 based CSP reduction
-        // bool can_satisfy_constraint(const string& param_word, const uint& param_letter_pos, const uint& letter_pos) const;
-        
         // equality operator, TODO: is this needed?
         bool operator==(const cw_variable& rhs) const;
-
-        // destructor
-        // ~cw_variable() = default;
-
-        // copy constructor
-
-        // copy assignment constructor
     };
 
     // operator to print out cw_variable for debug

--- a/src/cw_csp/cw_csp_data_types.h
+++ b/src/cw_csp/cw_csp_data_types.h
@@ -47,7 +47,6 @@ namespace cw_csp_data_types_ns {
         word_direction dir;    // direction of word of this var
         string pattern;        // original pattern used to populate domain
         word_domain domain;    // all possible words that fit
-        bool assigned = false; // true iff assigned to single value --> domain.size() == 1
 
         // standard constructor for cw_csp
         cw_variable(uint origin_row, uint origin_col, uint length, word_direction dir, string pattern, unordered_set<word_t> domain);

--- a/src/word_domain/word_domain.cpp
+++ b/src/word_domain/word_domain.cpp
@@ -389,6 +389,7 @@ size_t word_domain::remove_matching_words(uint index, char letter) {
             if(shared_ptr<trie_node> parent = node->parent.lock()) {
                 // downwards removal in trie
                 num_leafs = remove_children(node, index);
+                assert(num_leafs > 0);
                 total_leafs += num_leafs;
 
                 // upwards removal in trie
@@ -579,7 +580,7 @@ size_t word_domain::undo_prev_ac3_call() {
 /**
  * @brief get size of domain remaining for ac3 validity checking, whether or not domain is assigned
 */
-size_t word_domain::domain_size() const {
+size_t word_domain::size() const {
     if(assigned) {
         return assigned_value.has_value() ? 1l : 0l;
     }
@@ -616,7 +617,7 @@ unordered_set<char> word_domain::get_all_letters_at_index(uint index) const {
  * @brief get vector containing all words in the current domain
  * @returns unsorted vector of all words in the current domain
 */
-vector<word_t> word_domain::get_cur_domain() {
+vector<word_t> word_domain::get_cur_domain() const {
     vector<word_t> acc;
     collect_cur_domain(trie, "", acc);
     return acc;
@@ -629,7 +630,7 @@ vector<word_t> word_domain::get_cur_domain() {
  * @param fragment letters from traversal so far up to and not including the current node
  * @param acc accumulator vector to write back valid words to
 */
-void word_domain::collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc) {
+void word_domain::collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc) const {
     string fragment_with_cur_node = (node == trie) ? fragment : fragment + node->letter;
 
     // base case for leaf nodes

--- a/src/word_domain/word_domain.cpp
+++ b/src/word_domain/word_domain.cpp
@@ -124,6 +124,7 @@ word_domain::word_domain(string name, optional<string> filepath_opt, bool print_
             word_file.close();
 
         } else {
+            stringstream ss;
             ss << "word_domain got file of invalid type: " << filepath;
             utils->print_msg(&ss, FATAL);
             return;
@@ -214,6 +215,8 @@ void word_domain::add_word(word_t w) {
 
             add_word_to_trie(trie, w.word, 0);
 
+            stringstream ss;
+
             ss << "num_words: " << endl;
             for(uint i = 0; i < MAX_WORD_LEN; i++) {
                 for(char c = 'a'; c <= 'z'; c++) {
@@ -296,6 +299,7 @@ unordered_set<word_t> word_domain::find_matches(const string& pattern) {
  * @param fragment part of word matched already
 */
 void word_domain::traverse_to_find_matches(unordered_set<word_t>& matches, const string& pattern, uint pos, shared_ptr<trie_node> node, string fragment) {
+    stringstream ss;
     ss << "entering traverse_to_find_matches() w/ pattern " << pattern << " at pos " << pos 
        << " @ node " << node->letter;
     utils->print_msg(&ss, DEBUG);
@@ -395,6 +399,7 @@ size_t word_domain::remove_matching_words(uint index, char letter) {
                 // upwards removal in trie
                 remove_from_parents(node, num_leafs, static_cast<int>(index), true);
             } else {
+                stringstream ss;
                 ss << "parent of node index " << index << ", letter " << letter << " deleted early";
                 utils->print_msg(&ss, ERROR);
             }
@@ -547,6 +552,7 @@ size_t word_domain::undo_prev_ac3_call() {
                     assert_m(parent->children.count(node->letter) == 0, "parent node still contains edge to child in undo_prev_ac3_call() call");
                     parent->children.insert({node->letter, node});
                 } else {
+                    stringstream ss;
                     ss << "parent of node index " << i << ", letter " << j << " deleted early during restoration";
                     utils->print_msg(&ss, ERROR);
                 }
@@ -618,6 +624,10 @@ unordered_set<char> word_domain::get_all_letters_at_index(uint index) const {
  * @returns unsorted vector of all words in the current domain
 */
 vector<word_t> word_domain::get_cur_domain() const {
+    if(assigned) {
+        if(assigned_value.has_value()) return { assigned_value.value() };
+        return {};
+    }
     vector<word_t> acc;
     collect_cur_domain(trie, "", acc);
     return acc;

--- a/src/word_domain/word_domain.h
+++ b/src/word_domain/word_domain.h
@@ -62,13 +62,13 @@ namespace word_domain_ns {
             void unassign_domain() { assigned = false; assigned_value.reset(); }
 
             // get size of domain remaining, for ac3 validity checking
-            size_t domain_size() const;
+            size_t size() const;
 
             // get letters at an index, for AC-3 constraint satisfaction checking
             unordered_set<char> get_all_letters_at_index(uint index) const;
 
             // get all words in current domain to try to assign for backtracking
-            vector<word_t> get_cur_domain();
+            vector<word_t> get_cur_domain() const;
 
             // expose letters_at_indicies for testing
             array<array<letters_table_entry, NUM_ENGLISH_LETTERS>, MAX_WORD_LEN> get_letters_at_indices() { return letters_at_indices; }
@@ -124,7 +124,7 @@ namespace word_domain_ns {
             uint remove_children(shared_ptr<trie_node> node, uint index);
 
             // helper for get_cur_domain() to traverse trie and collect words
-            void collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc);
+            void collect_cur_domain(shared_ptr<trie_node> node, string fragment, vector<word_t>& acc) const;
     }; // word_domain
 }; // word_domain_ns
 

--- a/src/word_domain/word_domain.h
+++ b/src/word_domain/word_domain.h
@@ -61,6 +61,9 @@ namespace word_domain_ns {
             // unassign domain, restoring the preivous trie, used when all values fail in backtracking
             void unassign_domain() { assigned = false; assigned_value.reset(); }
 
+            // get assigned status
+            bool is_assigned() { return assigned; }
+
             // get size of domain remaining, for ac3 validity checking
             size_t size() const;
 

--- a/test/cw_csp/cw_csp_test.cpp
+++ b/test/cw_csp/cw_csp_test.cpp
@@ -534,13 +534,15 @@ TEST_CASE("cw_csp ac3_valid_constraint_duplicates", "[cw_csp],[ac3],[duplicates]
     // ############### valid crosswords ###############
 
     // simple crossword that requires duplicates
+    // note: while this is an illegal configuration, word_domain cannot detect variables in a 
+    //  constraint using the same word so it cannot detect that this is illegal, so expected is true
     stringstream contents_2_2_duplicate_invalid;
     contents_2_2_duplicate_invalid << WCD << WCD
                                    << WCD << WCD;
-    REQUIRE(dut->test_ac3_validity(2, 2, contents_2_2_duplicate_invalid.str(), dict_single_word, false));
+    REQUIRE(dut->test_ac3_validity(2, 2, contents_2_2_duplicate_invalid.str(), dict_single_word, true));
 
     // valid 6x7 crossword with complex intersections & mix of wildcards and letters
-    // forces two words to both be 'cat', but is allowed because they don't intersect
+    // forces two words to both be 'cat', but is allowed due to same reason as above
     stringstream contents_6_7_complex_valid;
     contents_6_7_complex_valid << WCD << BLK << BLK << WCD << BLK << 'p' 
                                << 't' << WCD << WCD << 'e' << BLK << BLK 
@@ -553,15 +555,14 @@ TEST_CASE("cw_csp ac3_valid_constraint_duplicates", "[cw_csp],[ac3],[duplicates]
 
     // ############### invalid crosswords ###############
 
-    // valid 6x7 crossword with complex intersections & mix of wildcards and letters
-    // forces two intersecting words to both be 'cat', which is not allowed
+    // invalid 6x7 crossword with complex intersections & mix of wildcards and letters
     stringstream contents_6_7_complex_invalid;
     contents_6_7_complex_invalid << WCD << BLK << BLK << WCD << BLK << 'p' 
                                  << 't' << WCD << WCD << 'e' << BLK << BLK 
                                  << WCD << BLK << BLK << WCD << WCD << WCD 
                                  << WCD << BLK << WCD << BLK << WCD << BLK 
                                  << BLK << BLK << 'a' << BLK << 'o' << BLK 
-                                 << WCD << 'a' << 't' << BLK << WCD << BLK 
+                                 << 'c' << 'o' << 't' << BLK << WCD << BLK 
                                  << BLK << 'n' << BLK << BLK << BLK << BLK;
     REQUIRE(dut->test_ac3_validity(6, 7, contents_6_7_complex_invalid.str(), dict_simple_path, false));
 }

--- a/test/word_domain/word_domain_test_driver.cpp
+++ b/test/word_domain/word_domain_test_driver.cpp
@@ -136,7 +136,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove(
 
             result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
             result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
-            result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());
+            result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->size());
         }
 
         for(int i = static_cast<int>(remove_params.size()) - 2; i >= 0; i--) {
@@ -145,7 +145,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove(
 
             result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[static_cast<uint>(i)], letters_at_indices, true));
             result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[static_cast<uint>(i)], letters_at_indices, false));
-            result &= check_condition("domain size preserved during restore", init_domain_size == num_removed + dut->domain_size());
+            result &= check_condition("domain size preserved during restore", init_domain_size == num_removed + dut->size());
         }
 
         if(remove_params.size() > 0) {
@@ -167,7 +167,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove(
 
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
-        result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());
+        result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->size());
     }
 
     return result;
@@ -214,7 +214,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove_assign(
 
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths[i], letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths[i], letters_at_indices, false));
-        result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->domain_size());
+        result &= check_condition("domain size preserved during remove", init_domain_size == num_removed + dut->size());
     }
 
     if(last_remaining.has_value()) {
@@ -228,7 +228,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove_assign(
 
     // try assigning candidates
     vector<word_t> candidates = dut->get_cur_domain();
-    result &= candidates.size() == dut->domain_size();
+    result &= candidates.size() == dut->size();
     for(word_t candidate : candidates) {
         dut->assign_domain(candidate);
         result &= test_num_letters_at_indicies_assign(candidate);
@@ -245,7 +245,7 @@ bool word_domain_test_driver::test_letters_at_indicies_remove_assign(
 
         result &= check_condition("letters_at_indicies num_words", letters_at_indicies_entries_equal(num_words_ground_truths.back(), letters_at_indices, true));
         result &= check_condition("letters_at_indicies num nodes", letters_at_indicies_entries_equal(num_nodes_ground_truths.back(), letters_at_indices, false));
-        result &= check_condition("domain size preserved during restore", init_domain_size == num_removed + dut->domain_size());
+        result &= check_condition("domain size preserved during restore", init_domain_size == num_removed + dut->size());
     }
 
     // final undo
@@ -310,7 +310,7 @@ bool word_domain_test_driver::test_get_all_letters_at_index(
 
     // try assigning candidates
     vector<word_t> candidates = dut->get_cur_domain();
-    result &= candidates.size() == dut->domain_size();
+    result &= candidates.size() == dut->size();
     for(word_t candidate : candidates) {
         dut->assign_domain(candidate);
         
@@ -359,7 +359,7 @@ bool word_domain_test_driver::test_get_all_letters_at_index(
 
     // try assigning candidates, again
     candidates = dut->get_cur_domain();
-    result &= candidates.size() == dut->domain_size();
+    result &= candidates.size() == dut->size();
     for(word_t candidate : candidates) {
         dut->assign_domain(candidate);
         
@@ -418,6 +418,7 @@ bool word_domain_test_driver::letters_at_indicies_entries_equal(
                 (test_num_words  && expected[i][j] != ground_truth[i][j].num_words) || 
                 (!test_num_words && expected[i][j] != ground_truth[i][j].nodes.size())
             ) {
+                stringstream ss;
                 ss << "letters_at_indicies_entries_equal() inequal at index: " << i << ", letter: " << j << ", test_num_words: " << test_num_words 
                    << ", expected: " << expected[i][j] << ", actual nodes: " << ground_truth[i][j].nodes.size() << ", actual words: " << ground_truth[i][j].num_words;
                 utils->print_msg(&ss, WARNING);

--- a/test/word_domain/word_domain_test_driver.h
+++ b/test/word_domain/word_domain_test_driver.h
@@ -71,7 +71,7 @@ namespace word_domain_test_driver_ns {
             );
             
             // basic check after remove tests that the domain is empty
-            bool test_domain_empty() { return dut->domain_size() == 0; }
+            bool test_domain_empty() { return dut->size() == 0; }
 
             // basic directed test for num_letters_at_index() after assigning domain
             bool test_num_letters_at_indicies_assign(word_t value);


### PR DESCRIPTION
## Overview
- integrate use of `word_domain` into `cw_csp`

## Details
- integrate `word_domain` to be used as the type of the `domain` field in `cw_variable` instead of `unordered_set<word_t>`
- remove now-unnecessary data structures tracking domain pruning from `cw_csp`, and the redundant `assigned` field from `cw_variable` 
- update `solve_backtracking()`, `ac3()`, `undo_ac3()`, and other minor functions to use `word_domain`
- adde domain resetting to backtracking in cw_csp to correct the inexhaustive search
- up till now, `common_parent` mistakenly included a `stringstream` for syntactic ease when printing messages. however, i had overlooked that `stringstream` is not copyable. `word_domain` inherits from common_parent and thus contained a stringstream, making `word_domain` (and in fact also `cw_csp`, `crossword`, and `cw_gen`) not copyable. by changing the type of `cw_variable` member `domain` from `unordered_set<word_t> ` to `word_domain`, this made the entire struct non copyable, which is needed for testing and future support of dynamic constraint satisfaction problems. to resolve this, the `stringstream` was removed from `common_parent`, and all uses of `cw_utils.print_msg()` were changed to first declare a local `stringstream` to use. this solution works, but is really ugly. this will need to be resolved in a future PR, as mentioned in #27 
- update `word_domain.get_cur_domain()` to account for domain assignment for easier syntax when retrieving the assigned value
- add `word_domain.is_assigned()` to make `cw_variable.assigned` redundant

## Testing
- existing test suite all passes
- one weakness of `word_domain` is that it cannot enforce two intersecting variables not choosing the same word. some tests needed to be adjusted as a result 
- manual testing found that generation sped up significantly for examples, as expected, which now generate instantaneously. even larger improvements in performance were found in cases like the 5x5 empty puzzle 
- it may be worth testing in the future if preemptively pruning what would be duplicate words from variable domains after an assignment would speed up generation, which is mentioned in #27 
- generation still seems slightly slow for larger puzzles, though, probably due to optimizations not yet being turned on for the compiler and the string building mentioned in #27 
- #23 seems to be resolved now with the integration of `word_domain`, but i'm not sure how exactly that fixed it

## Notes
- resolves #15
- resolves #17 
- resolves #23 
- manipulation of the `crossword` object in `cw_csp` seems overly complex and can probably be optimized further. however, this is not a high priority right now due to it having what seems like a relatively low overhead