### PR TITLE
Timetracker Performance Analysis

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -42,3 +42,6 @@ src/build
 # python
 src/data/scripts/__pycache__
 *.pyc
+
+# analysis output files
+/*.json

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -81,6 +81,8 @@
     "span": "cpp",
     "valarray": "cpp",
     "ranges": "cpp",
-    "filesystem": "cpp"
+    "filesystem": "cpp",
+    "iterator": "cpp",
+    "memory_resource": "cpp"
   }
 }

--- a/src/Makefile
+++ b/src/Makefile
@@ -44,6 +44,7 @@ OFILES = \
 		cw_csp_data_types.o \
 		\
 		cw_timetracker.o \
+		cw_timetracker_data_types.o \
 		\
 		word_domain.o \
 		word_domain_data_types.o \
@@ -63,6 +64,7 @@ HFILES = \
 		$(SRC_DIR)/$(CWCSP_DIR)/cw_csp_data_types.h \
 		\
 		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker.h \
+		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker_data_types.h \
 		\
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain.h \
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain_data_types.h \

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,10 +8,11 @@
 SRC_DIR=./
 
 # src dirs
-UTIL_DIR=utils
 COMMON_DIR=common
 CROSSWORD_DIR=crossword
 CWCSP_DIR=cw_csp
+CWTIMETRACKER_DIR=cw_timetracker
+UTIL_DIR=utils
 WORDDOMAIN_DIR=word_domain
 CWGEN_DIR=cli
 LIB_SRC_DIR=lib/src
@@ -42,6 +43,8 @@ OFILES = \
 		cw_csp.o \
 		cw_csp_data_types.o \
 		\
+		cw_timetracker.o \
+		\
 		word_domain.o \
 		word_domain_data_types.o \
 		\
@@ -58,6 +61,8 @@ HFILES = \
 		\
 		$(SRC_DIR)/$(CWCSP_DIR)/cw_csp.h \
 		$(SRC_DIR)/$(CWCSP_DIR)/cw_csp_data_types.h \
+		\
+		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker.h \
 		\
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain.h \
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain_data_types.h \

--- a/src/cli/cw_gen.cpp
+++ b/src/cli/cw_gen.cpp
@@ -38,9 +38,9 @@ string cw_gen::squash_options(vector<string> options) {
 */
 void cw_gen::build() {
     if(has_grid_contents) {
-        csp = make_unique<cw_csp>("puzzle", length, height, contents, dict_path[dict], display_progress_bar);
+        csp = make_unique<cw_csp>("puzzle", length, height, contents, dict_path[dict], display_progress_bar, enable_timetracker);
     } else {
-        csp = make_unique<cw_csp>("puzzle", length, height, dict_path[dict], display_progress_bar);
+        csp = make_unique<cw_csp>("puzzle", length, height, dict_path[dict], display_progress_bar, enable_timetracker);
     }
 }
 
@@ -72,6 +72,7 @@ int main(int argc, char** argv) {
         ("e,example",   examples_desc.str(),                                                     cxxopts::value<string>())
         ("v,verbosity", "Debug verbosity: " + cw_gen::squash_options(param_vals["verbosity"]),   cxxopts::value<string>()->default_value("fatal"))
         ("p,progress",  "Enable progress bar (default: false)",                                  cxxopts::value<bool>())
+        ("a,analysis",  "Enable JSON analysis file output",                                      cxxopts::value<string>())
         ("h,help",      "Print usage")
         ;
 
@@ -158,6 +159,18 @@ int main(int argc, char** argv) {
         cwgen->enable_progress_bar();
     }
 
+    // ############### cw_timetracker ###############
+
+    if(result.count("analysis")) {
+        string filepath = result["analysis"].as<string>();
+        if(filepath == "") {
+            cout << "Error: analysis output filepath must be nonempty, got: " << endl;
+            exit(1);
+        }
+
+        cwgen->enable_analysis();
+    }
+
     // ############### cw_csp solving ###############
 
     cwgen->build();
@@ -167,6 +180,13 @@ int main(int argc, char** argv) {
         cout << "Error: no valid crossword generated for the given parameters. " 
              << "Try an example, or use different dimensions, grid contents, or dictionary" << endl;
         exit(1);
+    }
+
+    // ############### cw_timetracker results ###############
+
+    if(result.count("analysis")) {
+        string filepath = result["analysis"].as<string>();
+        cwgen->save_analysis(filepath);
     }
 
     return 0;

--- a/src/cli/cw_gen.cpp
+++ b/src/cli/cw_gen.cpp
@@ -72,7 +72,7 @@ int main(int argc, char** argv) {
         ("e,example",   examples_desc.str(),                                                     cxxopts::value<string>())
         ("v,verbosity", "Debug verbosity: " + cw_gen::squash_options(param_vals["verbosity"]),   cxxopts::value<string>()->default_value("fatal"))
         ("p,progress",  "Enable progress bar (default: false)",                                  cxxopts::value<bool>())
-        ("a,analysis",  "Enable JSON analysis file output",                                      cxxopts::value<string>())
+        ("a,analysis",  "Name of JSON analysis file to generate if provided",                    cxxopts::value<string>())
         ("h,help",      "Print usage")
         ;
 
@@ -162,8 +162,7 @@ int main(int argc, char** argv) {
     // ############### cw_timetracker ###############
 
     if(result.count("analysis")) {
-        string filepath = result["analysis"].as<string>();
-        if(filepath == "") {
+        if(result["analysis"].as<string>() == "") {
             cout << "Error: analysis output filepath must be nonempty, got: " << endl;
             exit(1);
         }
@@ -185,8 +184,7 @@ int main(int argc, char** argv) {
     // ############### cw_timetracker results ###############
 
     if(result.count("analysis")) {
-        string filepath = result["analysis"].as<string>();
-        cwgen->save_analysis(filepath);
+        cwgen->save_analysis(result["analysis"].as<string>() + ".json");
     }
 
     return 0;

--- a/src/cli/cw_gen.h
+++ b/src/cli/cw_gen.h
@@ -36,6 +36,7 @@ namespace cw_gen_ns {
             void set_dict(string dict) { this->dict = dict; }
             void set_contents(string contents) { this->contents = contents; has_grid_contents = true; }
             void enable_progress_bar() { display_progress_bar = true; }
+            void enable_analysis() { enable_timetracker = true; }
 
             // for checking legal length of contents
             uint num_tiles() { return this->length * this->height; }
@@ -52,8 +53,8 @@ namespace cw_gen_ns {
             // return result after running solve()
             string result() { assert(csp->solved()); return csp->result(); }
 
-            // destructor, automatically destructs raii objects
-            ~cw_gen() {}
+            // generate analysis file, this object cannot be meaningfully used thereafter
+            void save_analysis(string filepath) { csp->save_timetracker_result(filepath); }
 
         private:
             // crossword constraint satisfaction problem to solve
@@ -74,6 +75,9 @@ namespace cw_gen_ns {
 
             // whether to display progress bar or not
             bool display_progress_bar = false;
+
+            // whether to enabled cw_timetracker or not
+            bool enable_timetracker = false;
     }; // cw_gen
 } // cw_gen_ns
 

--- a/src/common/common_data_types.h
+++ b/src/common/common_data_types.h
@@ -20,6 +20,7 @@
 #include <unordered_set>
 #include <unordered_map>
 #include <array>
+#include <chrono>
 
 #define MIN_WORD_LEN 2         // max length for a single word
 #define MAX_WORD_LEN 20        // max length for a single word

--- a/src/common/common_data_types.h
+++ b/src/common/common_data_types.h
@@ -54,7 +54,7 @@ using std::array;
 using std::pair;
 using std::optional;
 using std::chrono::time_point;
-using std::chrono::system_clock;
+using std::chrono::high_resolution_clock;
 
 // RAII
 using std::shared_ptr;

--- a/src/common/common_data_types.h
+++ b/src/common/common_data_types.h
@@ -53,6 +53,8 @@ using std::hash;
 using std::array;
 using std::pair;
 using std::optional;
+using std::chrono::time_point;
+using std::chrono::system_clock;
 
 // RAII
 using std::shared_ptr;

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -141,7 +141,7 @@ void cw_csp::initialize_csp() {
                         shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
                         ss << "adding new variable: " << *new_var;
                         utils->print_msg(&ss, DEBUG);
-                        variables.insert(new_var);
+                        variables.push_back(new_var);
                     }
 
                 } else {
@@ -161,7 +161,7 @@ void cw_csp::initialize_csp() {
             shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, HORIZONTAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
             ss << "adding new variable: " << *new_var;
             utils->print_msg(&ss, DEBUG);
-            variables.insert(new_var);
+            variables.push_back(new_var);
         }
     }
 
@@ -205,7 +205,7 @@ void cw_csp::initialize_csp() {
                         shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
                         ss << "adding new variable: " << *new_var;
                         utils->print_msg(&ss, DEBUG);
-                        variables.insert(new_var);
+                        variables.push_back(new_var);
                     }
 
                 } else {
@@ -225,7 +225,7 @@ void cw_csp::initialize_csp() {
             shared_ptr<cw_variable> new_var = make_shared<cw_variable>(cur_var_row, cur_var_col, cur_var_len, VERTICAL, word_pattern.str(), total_domain.find_matches(word_pattern.str()));
             ss << "adding new variable: " << *new_var;
             utils->print_msg(&ss, DEBUG);
-            variables.insert(new_var);
+            variables.push_back(new_var);
         }
     }
 
@@ -300,8 +300,8 @@ void cw_csp::initialize_csp() {
                 utils->print_msg(&ss, DEBUG);
 
                 // add arcs
-                constraints.insert(forward_arc);
-                constraints.insert(backwards_arc);
+                constraints.push_back(forward_arc);
+                constraints.push_back(backwards_arc);
             }
         }
     }
@@ -627,7 +627,8 @@ bool cw_csp::solve_backtracking(var_selection_method var_strategy, bool do_progr
         domain_copy = next_var->domain.get_cur_domain();
         auto compare = [](const word_t& lhs, const word_t& rhs) {
             if(lhs.score != rhs.score) return lhs.score > rhs.score;
-            return lhs.freq > rhs.freq;
+            if(lhs.freq != rhs.freq) return lhs.freq > rhs.freq;
+            return lhs.word > rhs.word;
         };
         sort(domain_copy.begin(), domain_copy.end(), compare);
     }

--- a/src/cw_csp/cw_csp.cpp
+++ b/src/cw_csp/cw_csp.cpp
@@ -14,11 +14,12 @@ using namespace cw_csp_ns;
  * @param length the length of puzzle to be created
  * @param height the height of puzzle to be created
  * @param filepath relative filepath to dictionary of words file
- * @param print_progress_bar displays progress bar iff true, default: false
+ * @param print_progress_bar displays progress bar iff true
+ * @param use_timetracker enables cw_timetracker iff true
 */
-cw_csp::cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar) 
+cw_csp::cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar, bool use_timetracker) 
         : common_parent(name), 
-          tracker("cw_csp", false), 
+          tracker("cw_csp", use_timetracker), 
           cw(name + " cw", length, height), 
           total_domain(name + " total_domain", filepath, print_progress_bar), 
           print_progress_bar(print_progress_bar) {
@@ -32,11 +33,12 @@ cw_csp::cw_csp(string name, uint length, uint height, string filepath, bool prin
  * @param height the height of puzzle to be created
  * @param contents the contents to populate puzzle with
  * @param filepath relative filepath to dictionary of words file
- * @param print_progress_bar displays progress bar iff true, default: false
+ * @param print_progress_bar displays progress bar iff true
+ * @param use_timetracker enables cw_timetracker iff true
 */
-cw_csp::cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar) 
+cw_csp::cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar, bool use_timetracker) 
         : common_parent(name), 
-          tracker("cw_csp", false), 
+          tracker("cw_csp", use_timetracker), 
           cw(name + " cw", length, height, contents), 
           total_domain(name + " total_domain", filepath, print_progress_bar), 
           print_progress_bar(print_progress_bar) {
@@ -407,19 +409,20 @@ bool cw_csp::solved() const {
     // check that all vars have one remaining domain value & satisfied
     for(shared_ptr<cw_variable> var_ptr : variables) {
         // check that all vars satisifed w/ one domain value
-        if(var_ptr->domain.size() != 1) return false;
-        if(!var_ptr->domain.is_assigned()) return false;
+        if(var_ptr->domain.size() != 1) { stamper.add_result("no"); return false; }
+        if(!var_ptr->domain.is_assigned()) { stamper.add_result("no"); return false; }
 
         // check that domain value is unique
-        if(used_words.count(var_ptr->domain.get_cur_domain().at(0)) > 0) return false;
+        if(used_words.count(var_ptr->domain.get_cur_domain().at(0)) > 0) { stamper.add_result("no"); return false; }
         used_words.insert(var_ptr->domain.get_cur_domain().at(0));
     }
 
     // check that all constraints satisfied
     for(shared_ptr<cw_constraint> constr_ptr : constraints) {
-        if(!constr_ptr->satisfied()) return false;
+        if(!constr_ptr->satisfied()) { stamper.add_result("no"); return false; }
     }
 
+    stamper.add_result("yes");
     return true;
 }
 

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -11,6 +11,8 @@
 #include "../common/common_parent.h"
 #include "../crossword/crossword_data_types.h"
 #include "../crossword/crossword.h"
+#include "../cw_timetracker/cw_timetracker_data_types.h"
+#include "../cw_timetracker/cw_timetracker.h"
 #include "../word_domain/word_domain_data_types.h"
 #include "../word_domain/word_domain.h"
 
@@ -18,6 +20,8 @@ using namespace cw_csp_data_types_ns;
 using namespace common_parent_ns;
 using namespace crossword_data_types_ns;
 using namespace crossword_ns;
+using namespace cw_timetracker_data_types_ns;
+using namespace cw_timetracker_ns;
 using namespace word_domain_data_types_ns;
 using namespace word_domain_ns;
 
@@ -50,8 +54,8 @@ namespace cw_csp_ns {
             // get string representation of solved cw for printing when solved() == true
             string result() const;
 
-            // destructor, automatically destructs raii objects
-            ~cw_csp() {}
+            // save timetracker results for analysis
+            void save_timetracker_result(string filepath) const { tracker.save_results(filepath); }
         
         protected:
             // helper func to populate variables & constraints
@@ -73,6 +77,9 @@ namespace cw_csp_ns {
             bool solve_backtracking(var_selection_method var_strategy, bool do_progress_bar);
 
         private:
+            // timetracker object for analysis
+            mutable cw_timetracker tracker;
+
             // crossword to be solved
             crossword cw;
 

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -74,7 +74,7 @@ namespace cw_csp_ns {
             void undo_overwrite_cw();
 
             // use backtracking to solve CSP
-            bool solve_backtracking(var_selection_method var_strategy, bool do_progress_bar);
+            bool solve_backtracking(var_selection_method var_strategy, bool do_progress_bar, uint depth);
 
         private:
             // timetracker object for analysis

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -32,10 +32,10 @@ namespace cw_csp_ns {
     class cw_csp : public common_parent {
         public:
             // constructor w/o puzzle contents
-            cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar = false);
+            cw_csp(string name, uint length, uint height, string filepath, bool print_progress_bar, bool use_timetracker);
 
             // constructor with puzzle contents
-            cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar = false);
+            cw_csp(string name, uint length, uint height, string contents, string filepath, bool print_progress_bar, bool use_timetracker);
 
             // read-only getters for testing
             unordered_set<cw_variable>                                get_variables()        const;

--- a/src/cw_csp/cw_csp.h
+++ b/src/cw_csp/cw_csp.h
@@ -87,8 +87,8 @@ namespace cw_csp_ns {
             word_domain total_domain;
 
             // csp structures
-            unordered_set<shared_ptr<cw_variable> >   variables;
-            unordered_set<shared_ptr<cw_constraint> > constraints;
+            vector<shared_ptr<cw_variable> >   variables;
+            vector<shared_ptr<cw_constraint> > constraints;
 
             // arc_dependencies[var_i] contains ptrs to all arcs of the form (var_k, var_i) 
             unordered_map<shared_ptr<cw_variable>, unordered_set<shared_ptr<cw_constraint> > > arc_dependencies;

--- a/src/cw_timetracker/cw_timetracker.cpp
+++ b/src/cw_timetracker/cw_timetracker.cpp
@@ -8,9 +8,126 @@
 
 using namespace cw_timetracker_ns;
 
+// ############### cw_timestep ###############
+
+/**
+ * @brief constructor for cw_timestep, starts measurement of a new timestep
+ * 
+ * @param type the type of this timestep
+ * @param name the name of this timestep
+ * @param id the id of this timestep for invariant checking
+ * @param prev ptr to parent step that this step is nested in and is a subset of, or this step is the root step if null
+*/
+cw_timetracker::cw_timestep::cw_timestep(ts_type_t type, string name, uint id, shared_ptr<cw_timestep> prev) 
+    : type(type), 
+      name(name), 
+      id(id), 
+      prev(prev), 
+      start(system_clock::now()), 
+      end(std::nullopt), 
+      result(std::nullopt) {
+    // do nothing, initializer list is enough
+}
+
+/**
+ * @brief resolves this timestep
+ * 
+ * @param id the expected id of this timestep
+ * @param result optional message for why/how this timestep ended
+ * @throws assertion_failure_exception iff id does not match
+*/
+void cw_timetracker::cw_timestep::resolve(uint id, string result) {
+    assert(this->id == id);
+    assert(!resolved());
+    assert(children.empty() || children.back()->resolved());
+
+    end = system_clock::now();
+    if(result != "") this->result = result;
+}
+
 // ############### cw_timetracker ###############
 
+/**
+ * @brief constructor for cw_timetracker, creates root timestep to encompass entire execution
+ * 
+ * @param init_name name for root level timestep
+ * @param enabled behaviors hold for this object iff enabled is true, otherwise all calls are ignored
+*/
+cw_timetracker::cw_timetracker(string init_name, bool enabled) : enabled(enabled), next_id(0) {
+    root = make_shared<cw_timestep>(init_name, next_id, nullptr);
+    cur = root;
+    next_id++;
+}
 
+/**
+ * @brief starts new timestep, nested inside the current deepest unresolved timestep (i.e. previous call)
+ * 
+ * @param type the type of the new timestep
+ * @param name the name or description of the new timestep
+ * @returns id of timestep, which is needed upon timestep resolution for invariant checking 
+*/
+uint cw_timetracker::start_timestep(ts_type_t type, string name) {
+    if(enabled) {
+        assert(cur);
+        assert(!cur->resolved());
+        assert(cur->children.empty() || cur->children.back()->resolved());
+
+        // add next layer
+        cur->children.push_back(make_shared<cw_timestep>(type, name, next_id, cur));
+        cur = cur->children.back();
+        return next_id++;
+    }
+
+    return 0;
+}
+
+/**
+ * @brief ends the current deepest unresolved timestep, whose id must match the id provided
+ * 
+ * @param id the id the timestep expected to be resolved
+ * @param result optional message for why/how this timestep ended
+ * @throws assertion_failure_exception iff id does not match
+*/
+void cw_timetracker::end_timestep(uint id, string result) {
+    if(enabled) {
+        assert(cur);
+        cur->resolve(id, result);
+        assert(cur = cur->prev.lock());
+    }
+}
+
+/**
+ * @brief saves the results in a JSON file at the specified path
+ * @throws assertion_failure_exception iff not all timesteps are resolved
+*/
+void cw_timetracker::save_results(string filepath) {
+    assert(root == cur);
+    assert(root->end.has_value());
+
+    // TODO: implement
+}
 
 // ############### cw_timestamper ###############
 
+/**
+ * @brief constructor for cw_timestamper, executes start_timestep() call for its timestep
+ * 
+ * @param tracker ref to cw_timetracker to make calls to
+ * @param type the type to assign to the cw_timestep this object manages
+ * @param name the name to assigned to the cw_timestep this object manages
+*/
+cw_timestamper::cw_timestamper(cw_timetracker& tracker, ts_type_t type, string name) : tracker(tracker), id(tracker.start_timestep(type, name)) {
+    // do nothing, other initializations are enough
+}
+
+
+/**
+ * @brief destructor for cw_timestamper, executes end_timestep() call for its timestep
+*/
+cw_timestamper::~cw_timestamper() {
+    if(result.has_value()) {
+        tracker.end_timestep(id, result.value());
+    } else {
+        tracker.end_timestep(id);
+    }
+}

--- a/src/cw_timetracker/cw_timetracker.cpp
+++ b/src/cw_timetracker/cw_timetracker.cpp
@@ -1,0 +1,16 @@
+// ==================================================================
+// Author: Ashley Zhang (ayz27@cornell.edu)
+// Date:   6/13/2024
+// Description: execution time tracker and related object implementations for cw_csp performance analysis
+// ==================================================================
+
+#include "cw_timetracker.h"
+
+using namespace cw_timetracker_ns;
+
+// ############### cw_timetracker ###############
+
+
+
+// ############### cw_timestamper ###############
+

--- a/src/cw_timetracker/cw_timetracker.cpp
+++ b/src/cw_timetracker/cw_timetracker.cpp
@@ -48,15 +48,17 @@ void cw_timetracker::cw_timestep::resolve(uint id, string result) {
 // ############### cw_timetracker ###############
 
 /**
- * @brief constructor for cw_timetracker, creates root timestep to encompass entire execution
+ * @brief constructor for cw_timetracker for cw_csp, creates root timestep to encompass entire execution
  * 
  * @param init_name name for root level timestep
  * @param enabled behaviors hold for this object iff enabled is true, otherwise all calls are ignored
 */
 cw_timetracker::cw_timetracker(string init_name, bool enabled) : enabled(enabled), next_id(0) {
-    root = make_shared<cw_timestep>(init_name, next_id, nullptr);
-    cur = root;
-    next_id++;
+    if(enabled) {
+        root = make_shared<cw_timestep>(TS_CSP_TOTAL, init_name, next_id, nullptr);
+        cur = root;
+        next_id++;
+    }
 }
 
 /**
@@ -100,12 +102,14 @@ void cw_timetracker::end_timestep(uint id, string result) {
  * @brief saves the results in a JSON file at the specified path
  * @throws assertion_failure_exception iff not all timesteps are resolved
 */
-void cw_timetracker::save_results(string filepath) {
-    assert(root == cur);
-    assert(root->end.has_value());
+// void cw_timetracker::save_results(string filepath) {
+//     if(enabled) {
+//         assert(root == cur);
+//         assert(root->end.has_value());
 
-    // TODO: implement
-}
+//         // TODO: implement
+//     }
+// }
 
 // ############### cw_timestamper ###############
 

--- a/src/cw_timetracker/cw_timetracker.cpp
+++ b/src/cw_timetracker/cw_timetracker.cpp
@@ -117,12 +117,12 @@ void cw_timetracker::save_results(string filepath) {
 // ############### json conversion ###############
 
 void cw_timetracker_ns::to_json(json& j, const shared_ptr<cw_timestep>& step) {
+    assert(step->end.has_value());
     j = json{
-        {"type", "hi"}, 
+        {"type", ts_type_name_map.at(step->type)}, 
         {"name", step->name}, 
-        // TODO: start
-        // TODO: children
-        // TODO: end 
+        {"duration", std::chrono::duration_cast<std::chrono::microseconds>(step->end.value() - step->start).count()},
+        {"children", step->children},
         {"result", step->result.has_value() ? step->result.value() : ""},
     };
 }

--- a/src/cw_timetracker/cw_timetracker.h
+++ b/src/cw_timetracker/cw_timetracker.h
@@ -18,13 +18,8 @@ namespace cw_timetracker_ns {
      * @brief type of tasks executed during a timestep
     */
     enum ts_type_t {
-        // common
-        TS_TOTAL_EXEC, // execution of the entire program
-
-        // word_domain
-        TS_WORD_DOMAIN_BUILD, // building of a word_domain
-
         // cw_csp
+        TS_CSP_TOTAL,             // all execution in cw_csp
         TS_CSP_BUILD,             // cw_csp constructor
         TS_CSP_INITIALIZE,        // cw_csp.initialize_csp()
         TS_CSP_SOLVE,             // cw_csp.solve()
@@ -120,9 +115,15 @@ namespace cw_timetracker_ns {
 
             // desctructor to resolve the timestep this object was created to manage
             ~cw_timestamper();
-            
-            // TODO: abide by rule of 5, make object non-copyable but movable
-        
+
+            // explicitly not copyable  
+            cw_timestamper(const cw_timestamper& other) = delete;            // copy constructor
+            cw_timestamper& operator=(const cw_timestamper& other) = delete; // copy assignment
+
+            // explicitly not movable
+            cw_timestamper(cw_timestamper&&) = delete;            // move constructor
+            cw_timestamper& operator=(cw_timestamper&&) = delete; // move assignment
+                    
         private:
             // cw_timetracker ref to make calls to
             cw_timetracker& tracker;

--- a/src/cw_timetracker/cw_timetracker.h
+++ b/src/cw_timetracker/cw_timetracker.h
@@ -63,7 +63,7 @@ namespace cw_timetracker_ns {
             // end previous timestep
             void end_timestep(uint id, string result = "");
 
-            // write results into JSON file
+            // write results into JSON file and resolves root timestep
             void save_results(string filepath);
 
             // basic constructor, initializes root timestep

--- a/src/cw_timetracker/cw_timetracker.h
+++ b/src/cw_timetracker/cw_timetracker.h
@@ -1,0 +1,92 @@
+// ==================================================================
+// Author: Ashley Zhang (ayz27@cornell.edu)
+// Date:   6/13/2024
+// Description: execution time tracker and related object declarations for cw_csp performance analysis
+// ==================================================================
+
+#ifndef CW_TIMETRACKER_H
+#define CW_TIMETRACKER_H
+
+#include "../common/common_data_types.h"
+
+using namespace common_data_types_ns;
+
+namespace cw_timetracker_ns {
+    /**
+     * @brief manages a tree of cw_timestep representing the whole search execution
+    */
+    class cw_timetracker {
+        public:
+            // start new timestep
+            uint start_timestep(string name);
+            
+            // end previous timestep
+            void end_timestep(uint id);
+
+            // write results into JSON file
+            void save_results(string filepath);
+
+            // basic constructor, initializes root timestep
+            cw_timetracker(string init_name);
+
+        protected:
+            /**
+             * @brief internal tree node representation of one division of time for a single execution step 
+            */
+            struct cw_timestep {
+                // description of this timestep
+                string name;
+
+                // id of this timestep, for invariant validation
+                uint id;
+
+                // parent step that this step is nested in and is a subset of, or this step is the root step if null
+                weak_ptr<cw_timestep> prev;
+
+                // timestamp right before this step started
+                string pre; 
+
+                // child timesteps nested in, or happened during, this timestep
+                vector<shared_ptr<cw_timestep> > children;
+
+                // timestamp right after this step ended, if finished
+                optional<string> post; 
+
+                // basic constructor
+                cw_timestep(string name, uint id, shared_ptr<cw_timestep> parent);
+            }; // cw_timestep
+
+        private:
+            // whether this object should do anything at all
+            const bool enabled;
+
+            // next id to assign, for invariant checking
+            uint next_id;
+
+            // root of whole execution tree
+            shared_ptr<cw_timestep> root;
+
+            // node of current deepest unresolved timestep
+            shared_ptr<cw_timestep> cur;
+    }; // cw_timetracker
+
+    /**
+     * @brief manages calls to a cw_timetracker object during a single timestep
+    */
+    class cw_timestamper {
+        public:
+            // constructor to initialize new timestep
+            cw_timestamper(cw_timetracker& tracker, string name);
+
+            // desctructor to resolve the timestep this object was created to manage
+            ~cw_timestamper();
+            
+            // TODO: abide by rule of 5, make object non-copyable but movable
+        
+        private:
+            // id of timestep this object manages
+            uint id;
+    }; // cw_timestamper
+}; // cw_timetracker_ns
+
+#endif // CW_TIMETRACKER_H

--- a/src/cw_timetracker/cw_timetracker.h
+++ b/src/cw_timetracker/cw_timetracker.h
@@ -9,11 +9,9 @@
 
 #include "../common/common_data_types.h"
 #include "cw_timetracker_data_types.h"
-#include "../lib/src/json.hpp"
 
 using namespace common_data_types_ns;
 using namespace cw_timetracker_data_types_ns;
-using json = nlohmann::json;
 
 namespace cw_timetracker_ns {
     /**

--- a/src/cw_timetracker/cw_timetracker.h
+++ b/src/cw_timetracker/cw_timetracker.h
@@ -11,8 +11,6 @@
 
 using namespace common_data_types_ns;
 
-using namespace std::chrono;
-
 namespace cw_timetracker_ns {
     /**
      * @brief type of tasks executed during a timestep

--- a/src/cw_timetracker/cw_timetracker_data_types.cpp
+++ b/src/cw_timetracker/cw_timetracker_data_types.cpp
@@ -21,5 +21,6 @@ namespace cw_timetracker_data_types_ns {
         {TS_CSP_UNDO_OVERWRITE_CW, "Undo Overwrite CW"}, 
         {TS_CSP_BACKTRACK_STEP,    "Solve Backtracking"}, 
         {TS_CSP_TRY_ASSIGN,        "Try Assign"}, 
+        {TS_CSP_GATHER_DOMAIN,     "Gather Domain"}, 
     };
 };

--- a/src/cw_timetracker/cw_timetracker_data_types.cpp
+++ b/src/cw_timetracker/cw_timetracker_data_types.cpp
@@ -1,0 +1,25 @@
+// ==================================================================
+// Author: Ashley Zhang (ayz27@cornell.edu)
+// Date:   6/14/2024
+// Description: data types implementations for execution time tracker and related object declarations for cw_csp performance analysis
+// ==================================================================
+
+#include "cw_timetracker_data_types.h"
+
+using namespace cw_timetracker_data_types_ns;
+
+namespace cw_timetracker_data_types_ns {
+    // mapping from timestep type to display name
+    unordered_map<ts_type_t, string> ts_type_name_map = {
+        {TS_CSP_TOTAL,             "Total"}, 
+        {TS_CSP_INITIALIZE,        "Initialize"}, 
+        {TS_CSP_SOLVE,             "Solve"}, 
+        {TS_CSP_SOLVED,            "Solved"}, 
+        {TS_CSP_AC3,               "AC3"}, 
+        {TS_CSP_UNDO_AC3,          "Undo AC3"}, 
+        {TS_CSP_OVERWRITE_CW,      "Overwrite CW"}, 
+        {TS_CSP_UNDO_OVERWRITE_CW, "Undo Overwrite CW"}, 
+        {TS_CSP_BACKTRACK_STEP,    "Solve Backtracking"}, 
+        {TS_CSP_TRY_ASSIGN,        "Try Assign"}, 
+    };
+};

--- a/src/cw_timetracker/cw_timetracker_data_types.h
+++ b/src/cw_timetracker/cw_timetracker_data_types.h
@@ -30,6 +30,7 @@ namespace cw_timetracker_data_types_ns {
         TS_CSP_UNDO_OVERWRITE_CW, // cw_csp.undo_overwrite_cw()
         TS_CSP_BACKTRACK_STEP,    // cw_csp.solve_backtracking()
         TS_CSP_TRY_ASSIGN,        // an attempt to assign word in cw_csp.solve_backtracking()
+        TS_CSP_GATHER_DOMAIN,     // get_cur_domain() call and sort in in cw_csp.solve_backtracking()
     };
 
     // mapping from timestep type to display name

--- a/src/cw_timetracker/cw_timetracker_data_types.h
+++ b/src/cw_timetracker/cw_timetracker_data_types.h
@@ -8,8 +8,11 @@
 #define CW_TIMETRACKER_DATA_TYPES_H
 
 #include "../common/common_data_types.h"
+#include "../lib/src/json.hpp"
 
 using namespace common_data_types_ns;
+
+using json = nlohmann::json;
 
 namespace cw_timetracker_data_types_ns {
     /**

--- a/src/cw_timetracker/cw_timetracker_data_types.h
+++ b/src/cw_timetracker/cw_timetracker_data_types.h
@@ -1,0 +1,36 @@
+// ==================================================================
+// Author: Ashley Zhang (ayz27@cornell.edu)
+// Date:   6/14/2024
+// Description: data types for execution time tracker and related object declarations for cw_csp performance analysis
+// ==================================================================
+
+#ifndef CW_TIMETRACKER_DATA_TYPES_H
+#define CW_TIMETRACKER_DATA_TYPES_H
+
+#include "../common/common_data_types.h"
+
+using namespace common_data_types_ns;
+
+namespace cw_timetracker_data_types_ns {
+    /**
+     * @brief type of tasks executed during a timestep
+    */
+    enum ts_type_t {
+        // cw_csp
+        TS_CSP_TOTAL,             // all execution in cw_csp
+        TS_CSP_INITIALIZE,        // cw_csp.initialize_csp()
+        TS_CSP_SOLVE,             // cw_csp.solve()
+        TS_CSP_SOLVED,            // cw_csp.solved()
+        TS_CSP_AC3,               // cw_csp.ac3()
+        TS_CSP_UNDO_AC3,          // cw_csp.undo_ac3()
+        TS_CSP_OVERWRITE_CW,      // cw_csp.overwrite_cw() 
+        TS_CSP_UNDO_OVERWRITE_CW, // cw_csp.undo_overwrite_cw()
+        TS_CSP_BACKTRACK_STEP,    // cw_csp.solve_backtracking()
+        TS_CSP_TRY_ASSIGN,        // an attempt to assign word in cw_csp.solve_backtracking()
+    };
+
+    // mapping from timestep type to display name
+    extern unordered_map<ts_type_t, string> ts_type_name_map;
+}; // cw_timetracker_data_types_ns
+
+#endif // CW_TIMETRACKER_DATA_TYPES_H

--- a/src/word_domain/word_domain.h
+++ b/src/word_domain/word_domain.h
@@ -108,7 +108,7 @@ namespace word_domain_ns {
             optional<word_t> assigned_value;
 
             // helper for filepath constructor to detect file type
-            bool has_suffix(const string& str, const string& suffix);
+            static bool has_suffix(const string& str, const string& suffix);
 
             // helper for filepath constructor to check if word is legal
             optional<string> parse_word(const string& word);

--- a/test/Makefile
+++ b/test/Makefile
@@ -9,10 +9,11 @@ SRC_DIR=../src
 TEST_DIR=./
 
 # src dirs
-UTIL_DIR=utils
 COMMON_DIR=common
 CROSSWORD_DIR=crossword
 CWCSP_DIR=cw_csp
+CWTIMETRACKER_DIR=cw_timetracker
+UTIL_DIR=utils
 WORDDOMAIN_DIR=word_domain
 LIB_SRC_DIR=lib/src
 
@@ -49,6 +50,8 @@ OFILES = \
 		cw_csp_test.o \
 		cw_csp_test_driver.o \
 		\
+		cw_timetracker.o \
+		\
 		word_domain.o \
 		word_domain_data_types.o \
 		word_domain_test.o \
@@ -69,6 +72,8 @@ HFILES = \
 		$(SRC_DIR)/$(CWCSP_DIR)/cw_csp.h \
 		$(SRC_DIR)/$(CWCSP_DIR)/cw_csp_data_types.h \
 		$(TEST_DIR)/$(CWCSP_DIR)/cw_csp_test_driver.h \
+		\
+		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker.h \
 		\
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain.h \
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain_data_types.h \

--- a/test/Makefile
+++ b/test/Makefile
@@ -51,6 +51,7 @@ OFILES = \
 		cw_csp_test_driver.o \
 		\
 		cw_timetracker.o \
+		cw_timetracker_data_types.o \
 		\
 		word_domain.o \
 		word_domain_data_types.o \
@@ -74,6 +75,7 @@ HFILES = \
 		$(TEST_DIR)/$(CWCSP_DIR)/cw_csp_test_driver.h \
 		\
 		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker.h \
+		$(SRC_DIR)/$(CWTIMETRACKER_DIR)/cw_timetracker_data_types.h \
 		\
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain.h \
 		$(SRC_DIR)/$(WORDDOMAIN_DIR)/word_domain_data_types.h \

--- a/test/cw_csp/cw_csp_test_driver.cpp
+++ b/test/cw_csp/cw_csp_test_driver.cpp
@@ -34,7 +34,7 @@ bool cw_csp_test_driver::test_constructor_empty(
 ) {
     stringstream dut_name;
     dut_name << name << " test_constructor_empty(): " << length << ", " << height;
-    dut = new cw_csp(dut_name.str(), length, height, filepath);
+    dut = new cw_csp(dut_name.str(), length, height, filepath, false, false);
 
     bool result = true;
     unordered_set<cw_variable>   result_variables   = dut->get_variables();
@@ -68,7 +68,7 @@ bool cw_csp_test_driver::test_constructor_contents(
 ) {
     stringstream dut_name;
     dut_name << name << " test_constructor_contents(): " << length << ", " << height;
-    dut = new cw_csp(dut_name.str(), length, height, contents, filepath);
+    dut = new cw_csp(dut_name.str(), length, height, contents, filepath, false, false);
 
     bool result = true;
     unordered_set<cw_variable>   result_variables   = dut->get_variables();
@@ -95,7 +95,7 @@ bool cw_csp_test_driver::test_constructor_contents(
 bool cw_csp_test_driver::test_ac3_validity(uint length, uint height, string contents, string filepath, bool expected_result) {
     stringstream dut_name;
     dut_name << name << " test_ac3_validity(): " << length << ", " << height;
-    dut = new cw_csp(dut_name.str(), length, height, contents, filepath);
+    dut = new cw_csp(dut_name.str(), length, height, contents, filepath, false, false);
 
     bool result = true;
     unordered_set<cw_variable> original_variables = dut->get_variables();
@@ -123,7 +123,7 @@ bool cw_csp_test_driver::test_ac3_validity(uint length, uint height, string cont
 bool cw_csp_test_driver::test_ac3(uint length, uint height, string contents, string filepath, bool expected_result, unordered_set<cw_variable>* expected_variables) {
     stringstream dut_name;
     dut_name << name << " test_ac3(): " << length << ", " << height;
-    dut = new cw_csp(dut_name.str(), length, height, contents, filepath);
+    dut = new cw_csp(dut_name.str(), length, height, contents, filepath, false, false);
 
     bool result = true;
     unordered_set<cw_variable> original_variables = dut->get_variables();
@@ -155,7 +155,7 @@ bool cw_csp_test_driver::test_ac3(uint length, uint height, string contents, str
 bool cw_csp_test_driver::test_backtracking_validity(uint length, uint height, string contents, string filepath, bool expected_result, bool do_print) {
     stringstream dut_name;
     dut_name << name << " test_backtracking_validity(): " << length << ", " << height;
-    dut = new cw_csp(dut_name.str(), length, height, contents, filepath);
+    dut = new cw_csp(dut_name.str(), length, height, contents, filepath, false, false);
     stringstream cw_result;
 
     bool result = check_condition(dut_name.str() + " backtracking validity", dut->solve(BACKTRACKING, MIN_REMAINING_VALUES) == expected_result);


### PR DESCRIPTION
## Overview
- add `cw_timetracker` and related dependent types to track subdivision of execution time in `cw_csp` for performance analysis and write results to a JSON file
- JSON file follows this format:
  * "children": list of recursive calls to subintervals
  * "duration_us": integer duration of interval, in microseconds
  * "name": optional string name of interval
  * "result": optional string result of interval
  * "type": string from a list of options of interval types
- ex: 
```json
{
    "children": [
        {
            "children": [],
            "duration_us": 952,
            "name": "",
            "result": "pass",
            "type": "AC3"
        },
        {
            "children": [],
            "duration_us": 10,
            "name": "",
            "result": "",
            "type": "Overwrite CW"
        },
        {
            "children": [
                {
                    "children": [],
                    "duration_us": 45,
                    "name": "",
                    "result": "yes",
                    "type": "Solved"
                }
            ],
            "duration_us": 48,
            "name": "depth: 10",
            "result": "solved",
            "type": "Solve Backtracking"
        }
    ],
    "duration_us": 1015,
    "name": "perth",
    "result": "",
    "type": "Try Assign"
}
```

## Details
- `cw_timetracker` manages a `cw_timestep` object which represents a time interval during one step of execution in `cw_csp` and can contain subintervals, thus forming a tree. each `cw_timestep` is is started and stopped with exactly one function call to `cw_timetracker`, which manages this invariant and builds the tree. these calls are made near-exclusively by the constructors and destructors `cw_timestamper` objects, which are created to represent one step of execution in `cw_csp` (the only exception to this rule is that `cw_timestamper` resolves its own root node upon saving its results to a JSON file and cannot be used thereafter)
- add `analysis` option to cli in `cw_gen` to enable generation of JSON file
- add tiebreaker for word frequency in `cw_csp.solve_backtracking()` and change the type of `variables` and `constraints` in cw_csp to be `vector<T>` instead of `unordered_set<T>` to make puzzle generation fully deterministic, i.e. the same parameters will now always generate the same output. this will help with debugging execution traces, and can easily be made nondeterministic again later with a random offset added to score values in each `word_t` 
- add depth parameter to `cw_csp.solve_backtracking()` for future use during analysis
- change `word_domain.has_suffix()` to be `static`

## Testing
- existing test suite all passes
- analysis is always disabled during testing

## Notes
- digging through the analysis output files of some manual runs, qualitatively, it seems like these executions would greatly benefit from a stronger arc consistency algorithm. the vast majority of backtracking steps in all of these executions iterate through their entire domain before failing, implying that the `cw_csp` was not valid when that backtracking step started. strong arc consistency, i.e. stronger constraint checking and more aggressive domain pruning, can reduce time wasted on these rabbit holes and wild goose chases because ideally, execution should never have to backtrack
- the print upgrade and timestamp tracking features in #27 were chosen to be executed with separate structures, of which only the latter is implemented in this PR
- the JSON files are being generated but are not currently being analyzed; open #29 
- the approach used to set `enabled` in `cw_timetracker` may be borrowed to help optimize verbosity checks when implementing the rest of #29 