### PR TITLE
Enable Compiler Optimizations

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -21,7 +21,7 @@ LIB_SRC_DIR=lib/src
 D = -D
 DEFINES = $(D) CW_TOP
 CPPFLAGS += -pipe
-CXXFLAGS += -g -W -Werror -Wall -Wconversion -Wextra -std=c++20 $(DEFINES)
+CXXFLAGS += -g -W -Werror -Wall -Wconversion -Wextra -O3 -std=c++20 $(DEFINES)
 INC=-I$(SRC_DIR)
 
 BIN = cw_gen

--- a/test/Makefile
+++ b/test/Makefile
@@ -24,7 +24,7 @@ CATCH_DIR=catch
 D = -D
 DEFINES = $(D) CW_TOP
 CPPFLAGS += -pipe
-CXXFLAGS += -g -W -Werror -Wall -Wconversion -Wextra -std=c++20 $(DEFINES)
+CXXFLAGS += -g -W -Werror -Wall -Wconversion -Wextra -Og -std=c++20 $(DEFINES)
 INC=-I$(SRC_DIR)
 
 BIN = cw_test_driver


### PR DESCRIPTION
## Overview
- enable g++ compiler optimizations

## Details
- in testing, optimization flag set to `-Og` to avoid making debugging difficult in the future
- in production, optimization flag set to `-O3` for maximum speedup

## Testing
- existing test suite all passes

## Notes
- across the board, execution is noticeably faster, especially building of `word_domain`