### PR TITLE
Add build workflow

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,24 @@
+name: Build
+
+on:
+  pull_request:
+    branches:
+      - main
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set build script permissions
+        working-directory: .
+        run: chmod +x build.sh
+
+      - name: Build
+        working-directory: .
+        run: |
+          sh build.sh


### PR DESCRIPTION
 ## Overview
- add workflow to run `build.sh`

## Details
- build workflow now enforced as an additional requirement for PRs before merging

## Testing
- existing test suite passes

## Notes
- resolves #47 